### PR TITLE
Add testimonial CRUD

### DIFF
--- a/app/Http/Controllers/Private/TestimonialController.php
+++ b/app/Http/Controllers/Private/TestimonialController.php
@@ -40,12 +40,12 @@ class TestimonialController extends Controller
     public function store(TestimonialStoreRequest $request)
     {
         if (app()->isLocal()) {
-            return to_route('testimonial.index')->with('error', 'Testimonial not created in demo mode');
+            return to_route('dashboard.testimonial.index')->with('error', 'Testimonial not created in demo mode');
         }
 
         TestimonialRepository::storeByRequest($request);
 
-        return to_route('testimonial.testimonial')->withSuccess('Testimonial created successfully.');
+        return to_route('dashboard.testimonial.index')->withSuccess('Testimonial created successfully.');
     }
 
     public function edit(Testimonial $testimonial)
@@ -58,7 +58,7 @@ class TestimonialController extends Controller
     public function update(TestimonialUpdateRequest $request, Testimonial $testimonial)
     {
         TestimonialRepository::updateByRequest($request, $testimonial);
-        return to_route('testimonial.index')->withSuccess('Testimonial updated successfully.');
+        return to_route('dashboard.testimonial.index')->withSuccess('Testimonial updated successfully.');
     }
 
     public function destroy(Testimonial $testimonial)
@@ -66,12 +66,12 @@ class TestimonialController extends Controller
         $testimonial->delete();
         $testimonial->is_active = false;
         $testimonial->save();
-        return to_route('testimonial.index')->withSuccess('Testimonial deleted successfully.');
+        return to_route('dashboard.testimonial.index')->withSuccess('Testimonial deleted successfully.');
     }
 
     public function restore($testimonial)
     {
         TestimonialRepository::query()->withTrashed()->find($testimonial)->restore();
-        return to_route('testimonial.index')->withSuccess('Testimonial restored successfully.');
+        return to_route('dashboard.testimonial.index')->withSuccess('Testimonial restored successfully.');
     }
 }

--- a/resources/js/components/testimonials/testimonialActionBtn.tsx
+++ b/resources/js/components/testimonials/testimonialActionBtn.tsx
@@ -1,0 +1,27 @@
+import { ITestimonial } from '@/types/testimonial';
+import { SquarePen, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+
+interface ITestimonialActionBtnProps {
+    row: {
+        original: ITestimonial;
+    };
+    onEdit?: (row: ITestimonial) => void;
+    onDelete?: (row: ITestimonial) => void;
+}
+
+export default function TestimonialActionBtn({ row, onEdit, onDelete }: ITestimonialActionBtnProps) {
+    return (
+        <div className="flex space-x-2">
+            <Button variant={'ghost'} size="icon" onClick={() => onEdit?.(row.original)}>
+                <SquarePen className="h-4 w-4" />
+                <span className="sr-only">Modifier</span>
+            </Button>
+
+            <Button variant={'ghost'} size="icon" onClick={() => onDelete?.(row.original)}>
+                <Trash2 className="text-red h-4 w-4" style={{ color: 'red' }} />
+                <span className="sr-only">Supprimer</span>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/testimonials/testimonialDataTable.tsx
+++ b/resources/js/components/testimonials/testimonialDataTable.tsx
@@ -1,0 +1,69 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import TestimonialActionBtn from './testimonialActionBtn';
+import { ITestimonial } from '@/types/testimonial';
+
+interface TestimonialDataTableProps {
+    testimonials: ITestimonial[];
+    onEditRow?: (row: ITestimonial) => void;
+    onDeleteRow?: (row: ITestimonial) => void;
+}
+
+export default function TestimonialDataTable({ testimonials, onEditRow, onDeleteRow }: TestimonialDataTableProps) {
+    const columns: ColumnDef<ITestimonial>[] = [
+        {
+            id: 'select',
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+                    onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                    aria-label="Select all"
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+        },
+        {
+            accessorKey: 'name',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Nom
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => {
+                const testimonial = row.original;
+                const name = testimonial.name;
+                const imageUrl = testimonial.media?.src || null;
+
+                return (
+                    <div className="flex items-center gap-2">
+                        {imageUrl && <img src={imageUrl} alt={name} className="h-8 w-8 rounded object-cover" />}
+                        <span className="capitalize">{name}</span>
+                    </div>
+                );
+            },
+        },
+        {
+            accessorKey: 'designation',
+            header: 'Poste',
+        },
+        {
+            accessorKey: 'rating',
+            header: 'Note',
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => <TestimonialActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} />,
+        },
+    ];
+
+    return <DataTable columns={columns} data={testimonials} filterColumn="name" />;
+}

--- a/resources/js/components/testimonials/testimonialForm.tsx
+++ b/resources/js/components/testimonials/testimonialForm.tsx
@@ -1,0 +1,117 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { InputFile } from '@/components/ui/inputFile';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/text-area';
+import { ITestimonial } from '@/types/testimonial';
+
+interface TestimonialFormProps {
+    closeDrawer?: () => void;
+    initialData?: ITestimonial;
+}
+
+const defaultValues: ITestimonial = {
+    name: '',
+    designation: '',
+    description: '',
+    rating: 1,
+    is_active: false,
+};
+
+export default function TestimonialForm({ closeDrawer, initialData }: TestimonialFormProps) {
+    const { t } = useTranslation();
+    const [file, setFile] = useState<File | null>(null);
+    const { data, setData, processing, errors, reset } = useForm<ITestimonial>(initialData || defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        if (!file && !initialData?.media) {
+            toast.error(t('testimonials.imageRequired', 'Veuillez sélectionner une image.'));
+            return;
+        }
+
+        const routeUrl = initialData?.id
+            ? route('dashboard.testimonial.update', initialData.id)
+            : route('dashboard.testimonial.store');
+
+        router.visit(routeUrl, {
+            method: initialData?.id ? 'put' : 'post',
+            data: {
+                name: data.name,
+                designation: data.designation,
+                description: data.description,
+                rating: data.rating,
+                is_active: data.is_active ? '1' : '0',
+                ...(file && { picture: file }),
+            },
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success(
+                    initialData?.id
+                        ? t('testimonials.updated', 'Témoignage mis à jour !')
+                        : t('testimonials.created', 'Témoignage créé !')
+                );
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Label htmlFor="name">{t('Name', 'Nom')}</Label>
+                <Input id="name" required value={data.name} onChange={(e) => setData('name', e.target.value)} disabled={processing} />
+                <InputError message={errors.name} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="designation">{t('Designation', 'Poste')}</Label>
+                <Input id="designation" required value={data.designation} onChange={(e) => setData('designation', e.target.value)} disabled={processing} />
+                <InputError message={errors.designation} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="description">{t('Description')}</Label>
+                <Textarea id="description" required value={data.description} onChange={(e) => setData('description', e.target.value)} disabled={processing} />
+                <InputError message={errors.description} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="rating">{t('Rating', 'Note')}</Label>
+                <Input id="rating" type="number" min={1} max={5} required value={data.rating} onChange={(e) => setData('rating', Number(e.target.value))} disabled={processing} />
+                <InputError message={errors.rating} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="picture">{t('Image')}</Label>
+                <InputFile
+                    id="picture"
+                    onFilesChange={(files) => {
+                        if (files && files.length > 0) {
+                            setFile(files[0]);
+                            setData('media_id', undefined as any);
+                        } else {
+                            setFile(null);
+                        }
+                    }}
+                    accept="image/*"
+                    multiple={false}
+                    disabled={processing}
+                />
+                <InputError message={errors.picture} />
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="is_active" checked={data.is_active} onCheckedChange={(value) => setData('is_active', !!value)} />
+                <Label htmlFor="is_active">{t('Active', 'Actif')}</Label>
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {initialData?.id ? t('Update', 'Mettre à jour') : t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}
+

--- a/resources/js/components/testimonials/testimonialToolBar.tsx
+++ b/resources/js/components/testimonials/testimonialToolBar.tsx
@@ -1,0 +1,34 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface ITestimonialToolBarProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function TestimonialToolBar({ FormComponent, open, setOpen }: ITestimonialToolBarProps) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('Testimonials', 'Témoignages')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add testimonial', 'Ajouter un témoignage')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && (
+                <Drawer title={t('Testimonials.add', 'Ajouter un témoignage')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/testimonials/index.tsx
+++ b/resources/js/pages/dashboard/testimonials/index.tsx
@@ -1,7 +1,14 @@
 import AppLayout from '@/layouts/dashboard/app-layout';
 import { SharedData, type BreadcrumbItem } from '@/types';
-import { Head, usePage } from '@inertiajs/react';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import TestimonialForm from '@/components/testimonials/testimonialForm';
+import TestimonialToolBar from '@/components/testimonials/testimonialToolBar';
+import TestimonialDataTable from '@/components/testimonials/testimonialDataTable';
+import { ITestimonial } from '@/types/testimonial';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -18,12 +25,66 @@ export default function DashboardTestimonial() {
     const { t } = useTranslation();
     const { data } = usePage<SharedData>().props;
 
+    const [testimonials, setTestimonials] = useState<ITestimonial[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<ITestimonial | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && data.testimonials?.data) {
+            setTestimonials(data.testimonials.data);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.testimonial.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('testimonials.deleted', 'Témoignage supprimé'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    const handleOpenEdit = (row: ITestimonial) => {
+        setSelected(row);
+        setOpenForm(true);
+    };
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-                <div className="">
-                    <h1>{t('Testimonials')}</h1>
+                <TestimonialToolBar
+                    FormComponent={<TestimonialForm closeDrawer={() => setOpenForm(false)} initialData={selected} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete testimonial', 'Supprimer le témoignage')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer ce témoignage ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {testimonials && (
+                        <TestimonialDataTable
+                            testimonials={testimonials}
+                            onEditRow={handleOpenEdit}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
                 </div>
             </div>
         </AppLayout>

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -1,5 +1,6 @@
 import { IDataWithPagination } from ".";
 import { IBlog, IBlogCategory } from "./blogs";
+import { ITestimonial } from "./testimonial";
 
 
 export enum PeriodicityUnitEnum {
@@ -258,4 +259,6 @@ export interface ICustomSharedData {
         categories?: IBlogCategory[];
         single: IBlog
     }
+
+    testimonials?: IDataWithPagination<ITestimonial>
 }

--- a/resources/js/types/testimonial.d.ts
+++ b/resources/js/types/testimonial.d.ts
@@ -1,0 +1,12 @@
+export interface ITestimonial {
+    id?: number;
+    name: string;
+    designation: string;
+    description: string;
+    rating: number;
+    is_active: boolean;
+    media?: IMedia;
+    media_id?: number;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -83,6 +83,9 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::get('create',         [TestimonialController::class, 'create'])->name('dashboard.testimonial.create');
         Route::get('edit/{slug}',    [TestimonialController::class, 'edit'])->name('dashboard.testimonial.edit');
         Route::post('create',        [TestimonialController::class, 'store'])->name('dashboard.testimonial.store');
+        Route::put('update/{testimonial}', [TestimonialController::class, 'update'])->name('dashboard.testimonial.update');
+        Route::delete('delete/{testimonial}', [TestimonialController::class, 'destroy'])->name('dashboard.testimonial.delete');
+        Route::post('restore/{testimonial}', [TestimonialController::class, 'restore'])->name('dashboard.testimonial.restore');
     });
 
 


### PR DESCRIPTION
## Summary
- allow testimonial CRUD routes
- implement testimonial controller redirects
- add types and components for dashboard testimonial management

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: Failed opening required '/workspace/server/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6871d795628c83338a20f50926c0db89