### PR TITLE
Add FAQ CRUD

### DIFF
--- a/app/Http/Controllers/PublicAbstractController.php
+++ b/app/Http/Controllers/PublicAbstractController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Repositories\CategoryRepository;
 use App\Repositories\CourseRepository;
+use App\Repositories\FaqRepository;
 
 abstract class PublicAbstractController extends Controller
 {
@@ -35,6 +36,7 @@ abstract class PublicAbstractController extends Controller
         return [
             'categories_with_courses' => $this->courseWithCategoryTree(true),
             'asset_path'              => asset(''),
+            'faqs'                    => FaqRepository::query()->where('is_active', true)->get(),
         ];
     }
 }

--- a/app/Http/Requests/FaqStoreRequest.php
+++ b/app/Http/Requests/FaqStoreRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FaqStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'question' => 'required|string',
+            'answer' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/FaqUpdateRequest.php
+++ b/app/Http/Requests/FaqUpdateRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FaqUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'question' => 'required|string',
+            'answer' => 'required|string',
+        ];
+    }
+}

--- a/app/Models/Faq.php
+++ b/app/Models/Faq.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Faq extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $guarded = ['id'];
+}

--- a/app/Repositories/FaqRepository.php
+++ b/app/Repositories/FaqRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\Faq;
+
+class FaqRepository extends Repository
+{
+    public static function model()
+    {
+        return Faq::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'question' => $request->question,
+            'answer' => $request->answer,
+            'is_active' => $request->has('is_active') ? true : false,
+        ]);
+    }
+
+    public static function updateByRequest($request, Faq $faq)
+    {
+        return self::update($faq, [
+            'question' => $request->question ?? $faq->question,
+            'answer' => $request->answer ?? $faq->answer,
+            'is_active' => $request->has('is_active') ? true : $faq->is_active,
+        ]);
+    }
+}

--- a/database/migrations/2025_07_12_035300_create_faqs_table.php
+++ b/database/migrations/2025_07_12_035300_create_faqs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('faqs', function (Blueprint $table) {
+            $table->id();
+            $table->string('question');
+            $table->text('answer');
+            $table->boolean('is_active')->default(true);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('faqs');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -35,6 +35,7 @@ class DatabaseSeeder extends Seeder
             // Other seeders can be added here
 
             TestimonialSeeder::class,
+            FaqSeeder::class,
         ]);
     }
 }

--- a/database/seeders/FaqSeeder.php
+++ b/database/seeders/FaqSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Faq;
+use Illuminate\Database\Seeder;
+
+class FaqSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $faqs = [
+            [
+                'question' => "Qu'est ce que TestPro?",
+                'answer' => "TestPro est un leader dans la formation certifiante en test logiciel et en ingénierie des exigences, offrant des certifications reconnues comme ISTQB, IQBBA et IREB. L'école TestPro s'engage à former des professionnels pour répondre aux besoins croissants du marché technologique en Afrique et à l'international.",
+            ],
+            [
+                'question' => 'Quels services offrez-vous?',
+                'answer' => "<div>Nous offrons plusieurs services, notamment :</div> <br /><ul><li> • Des formations certifiantes en tests logiciels et en ingénierie des exigences</li><li> • La mise à disposition de testeurs professionnels pour accompagner les entreprises dans leurs projets.</li><li> • Des services d’externalisation des tests réalisés dans nos locaux, en mode régie, pour une gestion collective des ressources tout au long du cycle de vie du développement logiciel.</li></ul>",
+            ],
+            [
+                'question' => "A qui s'adressent nos formations?",
+                'answer' => "Nos formations s'adressent aux professionnels souhaitant se spécialiser en tests logiciels et ingénierie des exigences, ainsi qu'aux entreprises souhaitant renforcer les compétences de leurs équipes face aux défis du marché technologique.",
+            ],
+            [
+                'question' => ' Pourquoi choisir TestPro pour vos besoins en test logiciel ?',
+                'answer' => "Nous nous engageons à offrir :\n\nUne expertise pointue et reconnue dans le domaine des tests logiciels.\nUne approche personnalisée pour chaque projet.\nUne contribution à l’innovation et à l’excellence technologique.",
+            ],
+            [
+                'question' => 'Où se trouvent vos locaux et vos formations sont-elles disponibles en ligne ?',
+                'answer' => 'Nos locaux sont situés en Côte d’Ivoire, et nous proposons également des formations en ligne pour permettre à nos apprenants d’apprendre à leur rythme, où qu’ils soient.',
+            ],
+            [
+                'question' => 'Comment puis-je m’inscrire ou bénéficier de vos services ?',
+                'answer' => 'Pour vous inscrire ou solliciter nos services, vous pouvez :<ul><li>Remplir le formulaire sur notre site web.</li><li>Nous contacter par téléphone ou par email via la rubrique "Contact".</li><li>Vous rendre directement dans nos locaux pour une assistance personnalisée.</li></ul>',
+            ],
+        ];
+
+        foreach ($faqs as $faq) {
+            Faq::create($faq);
+        }
+    }
+}

--- a/resources/js/components/faq/Faq.tsx
+++ b/resources/js/components/faq/Faq.tsx
@@ -1,7 +1,9 @@
 import { CLASS_NAME } from '@/data/styles/style.constant';
+import { usePage } from '@inertiajs/react';
 import { useState } from 'react';
+import { IFaq, SharedData } from '@/types';
 
-export const FAQ: { question: string; answer: string }[] = [
+const DEFAULT_FAQ: IFaq[] = [
     {
         question: "Qu'est ce que TestPro?",
         answer: "TestPro est un leader dans la formation certifiante en test logiciel et en ingénierie des exigences, offrant des certifications reconnues comme ISTQB, IQBBA et IREB. L'école TestPro s'engage à former des professionnels pour répondre aux besoins croissants du marché technologique en Afrique et à l'international.",
@@ -51,7 +53,8 @@ export const FAQ: { question: string; answer: string }[] = [
 ];
 
 const Faq: React.FC = () => {
-    // Initialize openIndex to 0 to open the first item by default
+    const { data } = usePage<SharedData>().props;
+    const faqs: IFaq[] = (data as any)?.faqs ?? DEFAULT_FAQ;
     const [openIndex, setOpenIndex] = useState<number | null>(0);
 
     const toggleAccordion = (index: number) => {
@@ -78,7 +81,7 @@ const Faq: React.FC = () => {
                     </div>
 
                     <div className="toc-accordion mx-auto md:max-w-[738px]" id="tablesOfContentAccordion">
-                        {FAQ.map((faq, index) => (
+                        {faqs.map((faq, index) => (
                             <div
                                 key={index}
                                 className="toc-accordion-item mb-[15px] rounded-md bg-white text-black last:mb-0 dark:bg-[#0c1427] dark:text-white"

--- a/resources/js/components/faqs/faqActionBtn.tsx
+++ b/resources/js/components/faqs/faqActionBtn.tsx
@@ -1,0 +1,27 @@
+import { IFaq } from '@/types/faq';
+import { SquarePen, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+
+interface IFaqActionBtnProps {
+    row: {
+        original: IFaq;
+    };
+    onEdit?: (row: IFaq) => void;
+    onDelete?: (row: IFaq) => void;
+}
+
+export default function FaqActionBtn({ row, onEdit, onDelete }: IFaqActionBtnProps) {
+    return (
+        <div className="flex space-x-2">
+            <Button variant={'ghost'} size="icon" onClick={() => onEdit?.(row.original)}>
+                <SquarePen className="h-4 w-4" />
+                <span className="sr-only">Modifier</span>
+            </Button>
+
+            <Button variant={'ghost'} size="icon" onClick={() => onDelete?.(row.original)}>
+                <Trash2 className="text-red h-4 w-4" style={{ color: 'red' }} />
+                <span className="sr-only">Supprimer</span>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/faqs/faqDataTable.tsx
+++ b/resources/js/components/faqs/faqDataTable.tsx
@@ -1,0 +1,49 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import FaqActionBtn from './faqActionBtn';
+import { IFaq } from '@/types/faq';
+
+interface FaqDataTableProps {
+    faqs: IFaq[];
+    onEditRow?: (row: IFaq) => void;
+    onDeleteRow?: (row: IFaq) => void;
+}
+
+export default function FaqDataTable({ faqs, onEditRow, onDeleteRow }: FaqDataTableProps) {
+    const columns: ColumnDef<IFaq>[] = [
+        {
+            id: 'select',
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+                    onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                    aria-label="Select all"
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+        },
+        {
+            accessorKey: 'question',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Question
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => <FaqActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} />,
+        },
+    ];
+
+    return <DataTable columns={columns} data={faqs} filterColumn="question" />;
+}

--- a/resources/js/components/faqs/faqForm.tsx
+++ b/resources/js/components/faqs/faqForm.tsx
@@ -1,0 +1,69 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/text-area';
+import { IFaq } from '@/types/faq';
+
+interface FaqFormProps {
+    closeDrawer?: () => void;
+    initialData?: IFaq;
+}
+
+const defaultValues: IFaq = {
+    question: '',
+    answer: '',
+    is_active: true,
+};
+
+export default function FaqForm({ closeDrawer, initialData }: FaqFormProps) {
+    const { t } = useTranslation();
+    const { data, setData, processing, errors, reset } = useForm<IFaq>(initialData || defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        const routeUrl = initialData?.id
+            ? route('dashboard.faqs.update', initialData.id)
+            : route('dashboard.faqs.store');
+
+        router.visit(routeUrl, {
+            method: initialData?.id ? 'put' : 'post',
+            data: {
+                question: data.question,
+                answer: data.answer,
+                is_active: data.is_active ? '1' : '0',
+            },
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success(
+                    initialData?.id ? t('faqs.updated', 'FAQ mise à jour !') : t('faqs.created', 'FAQ créée !')
+                );
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Label htmlFor="question">{t('Question')}</Label>
+                <Input id="question" required value={data.question} onChange={(e) => setData('question', e.target.value)} disabled={processing} />
+                <InputError message={errors.question} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="answer">{t('Answer')}</Label>
+                <Textarea id="answer" required value={data.answer} onChange={(e) => setData('answer', e.target.value)} disabled={processing} />
+                <InputError message={errors.answer} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {initialData?.id ? t('Update', 'Mettre à jour') : t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/faqs/faqToolBar.tsx
+++ b/resources/js/components/faqs/faqToolBar.tsx
@@ -1,0 +1,34 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface IFaqToolBarProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function FaqToolBar({ FormComponent, open, setOpen }: IFaqToolBarProps) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('FAQs')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add faq', 'Ajouter une FAQ')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && (
+                <Drawer title={t('FAQs.add', 'Ajouter une FAQ')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/faqs/index.tsx
+++ b/resources/js/pages/dashboard/faqs/index.tsx
@@ -1,7 +1,14 @@
 import AppLayout from '@/layouts/dashboard/app-layout';
 import { SharedData, type BreadcrumbItem } from '@/types';
-import { Head, usePage } from '@inertiajs/react';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import FaqForm from '@/components/faqs/faqForm';
+import FaqToolBar from '@/components/faqs/faqToolBar';
+import FaqDataTable from '@/components/faqs/faqDataTable';
+import { IFaq } from '@/types/faq';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -18,12 +25,68 @@ export default function DashboardFaqs() {
     const { t } = useTranslation();
     const { data } = usePage<SharedData>().props;
 
+    const [faqs, setFaqs] = useState<IFaq[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<IFaq | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && (data.faqs as any)?.data) {
+            setFaqs((data.faqs as any).data);
+        } else if (data && Array.isArray(data.faqs)) {
+            setFaqs(data.faqs as any);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.faqs.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('faqs.deleted', 'FAQ supprimée'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    const handleOpenEdit = (row: IFaq) => {
+        setSelected(row);
+        setOpenForm(true);
+    };
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-                <div className="">
-                    <h1>{t('FAQs')}</h1>
+                <FaqToolBar
+                    FormComponent={<FaqForm closeDrawer={() => setOpenForm(false)} initialData={selected} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete faq', 'Supprimer la FAQ')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer cette FAQ ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {faqs && (
+                        <FaqDataTable
+                            faqs={faqs}
+                            onEditRow={handleOpenEdit}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
                 </div>
             </div>
         </AppLayout>

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -1,6 +1,7 @@
 import { IDataWithPagination } from ".";
 import { IBlog, IBlogCategory } from "./blogs";
 import { ITestimonial } from "./testimonial";
+import { IFaq } from "./faq";
 
 
 export enum PeriodicityUnitEnum {
@@ -261,4 +262,5 @@ export interface ICustomSharedData {
     }
 
     testimonials?: IDataWithPagination<ITestimonial>
+    faqs?: IFaq[]
 }

--- a/resources/js/types/faq.d.ts
+++ b/resources/js/types/faq.d.ts
@@ -1,0 +1,8 @@
+export interface IFaq {
+    id?: number;
+    question: string;
+    answer: string;
+    is_active?: boolean;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -110,5 +110,8 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
     ], function () {
         Route::get('',               [FaqController::class, 'index'])->name('dashboard.faqs.index');
         Route::post('create',        [FaqController::class, 'store'])->name('dashboard.faqs.store');
+        Route::put('update/{faq}',   [FaqController::class, 'update'])->name('dashboard.faqs.update');
+        Route::delete('delete/{faq}', [FaqController::class, 'destroy'])->name('dashboard.faqs.delete');
+        Route::post('restore/{faq}', [FaqController::class, 'restore'])->name('dashboard.faqs.restore');
     });
 });


### PR DESCRIPTION
## Summary
- implement `Faq` model, repository, migration and seeder
- wire FAQ data into public controller defaults
- build CRUD controller and routes for dashboard
- add React components to manage FAQs in backoffice
- update front FAQ component to read data from API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `composer test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6871db82721c8333b6bec79293836ea7