### PR TITLE
Ajout fonctionnalité références formations

### DIFF
--- a/app/Http/Controllers/Private/ReferenceController.php
+++ b/app/Http/Controllers/Private/ReferenceController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ReferenceStoreRequest;
+use App\Http\Requests\ReferenceUpdateRequest;
+use App\Models\Reference;
+use App\Repositories\ReferenceRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class ReferenceController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->search ? strtolower($request->search) : null;
+
+        $references = ReferenceRepository::query()
+            ->when($search, function ($query) use ($search) {
+                $query->where('text', 'like', '%' . $search . '%');
+            })
+            ->with('media')
+            ->withTrashed()
+            ->latest('id')
+            ->paginate(15)
+            ->withQueryString();
+
+        $data = [
+            'references' => $references,
+        ];
+
+        return Inertia::render('dashboard/references/index', [
+            'data' => $data,
+        ]);
+    }
+
+    public function store(ReferenceStoreRequest $request)
+    {
+        if (app()->isLocal()) {
+            return to_route('dashboard.references.index')->with('error', 'Reference not created in demo mode');
+        }
+
+        ReferenceRepository::storeByRequest($request);
+
+        return to_route('dashboard.references.index')->withSuccess('Reference created successfully.');
+    }
+
+    public function update(ReferenceUpdateRequest $request, Reference $reference)
+    {
+        ReferenceRepository::updateByRequest($request, $reference);
+        return to_route('dashboard.references.index')->withSuccess('Reference updated successfully.');
+    }
+
+    public function destroy(Reference $reference)
+    {
+        $reference->delete();
+        $reference->is_active = false;
+        $reference->save();
+        return to_route('dashboard.references.index')->withSuccess('Reference deleted successfully.');
+    }
+
+    public function restore($reference)
+    {
+        ReferenceRepository::query()->withTrashed()->find($reference)->restore();
+        return to_route('dashboard.references.index')->withSuccess('Reference restored successfully.');
+    }
+}

--- a/app/Http/Requests/ReferenceStoreRequest.php
+++ b/app/Http/Requests/ReferenceStoreRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReferenceStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'text' => 'nullable|string',
+            'media_id' => 'required|exists:media,id',
+        ];
+    }
+}

--- a/app/Http/Requests/ReferenceUpdateRequest.php
+++ b/app/Http/Requests/ReferenceUpdateRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReferenceUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'text' => 'nullable|string',
+            'media_id' => 'nullable|exists:media,id',
+        ];
+    }
+}

--- a/app/Models/Reference.php
+++ b/app/Models/Reference.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
+
+class Reference extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $guarded = ['id'];
+
+    public function media(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'media_id');
+    }
+
+    public function mediaPath(): Attribute
+    {
+        $media = null;
+        if ($this->media && Storage::exists($this->media->src)) {
+            $media = Storage::url($this->media->src);
+        }
+
+        return Attribute::make(
+            get: fn () => $media,
+        );
+    }
+}

--- a/app/Repositories/ReferenceRepository.php
+++ b/app/Repositories/ReferenceRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\Reference;
+
+class ReferenceRepository extends Repository
+{
+    public static function model()
+    {
+        return Reference::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'text' => $request->text,
+            'media_id' => $request->media_id,
+            'is_active' => $request->has('is_active') ? true : false,
+        ]);
+    }
+
+    public static function updateByRequest($request, Reference $reference)
+    {
+        return self::update($reference, [
+            'text' => $request->text ?? $reference->text,
+            'media_id' => $request->media_id ?? $reference->media_id,
+            'is_active' => $request->has('is_active') ? true : $reference->is_active,
+        ]);
+    }
+}

--- a/database/migrations/2025_07_12_041000_create_references_table.php
+++ b/database/migrations/2025_07_12_041000_create_references_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('references', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('media_id')->constrained('media')->cascadeOnDelete();
+            $table->string('text')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('references');
+    }
+};

--- a/resources/js/components/references/referenceActionBtn.tsx
+++ b/resources/js/components/references/referenceActionBtn.tsx
@@ -1,0 +1,27 @@
+import { IReference } from '@/types/reference';
+import { SquarePen, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+
+interface IReferenceActionBtnProps {
+    row: {
+        original: IReference;
+    };
+    onEdit?: (row: IReference) => void;
+    onDelete?: (row: IReference) => void;
+}
+
+export default function ReferenceActionBtn({ row, onEdit, onDelete }: IReferenceActionBtnProps) {
+    return (
+        <div className="flex space-x-2">
+            <Button variant={'ghost'} size="icon" onClick={() => onEdit?.(row.original)}>
+                <SquarePen className="h-4 w-4" />
+                <span className="sr-only">Modifier</span>
+            </Button>
+
+            <Button variant={'ghost'} size="icon" onClick={() => onDelete?.(row.original)}>
+                <Trash2 className="text-red h-4 w-4" style={{ color: 'red' }} />
+                <span className="sr-only">Supprimer</span>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/references/referenceDataTable.tsx
+++ b/resources/js/components/references/referenceDataTable.tsx
@@ -1,0 +1,61 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import ReferenceActionBtn from './referenceActionBtn';
+import { IReference } from '@/types/reference';
+
+interface ReferenceDataTableProps {
+    references: IReference[];
+    onEditRow?: (row: IReference) => void;
+    onDeleteRow?: (row: IReference) => void;
+}
+
+export default function ReferenceDataTable({ references, onEditRow, onDeleteRow }: ReferenceDataTableProps) {
+    const columns: ColumnDef<IReference>[] = [
+        {
+            id: 'select',
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+                    onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                    aria-label="Select all"
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+        },
+        {
+            accessorKey: 'text',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Texte
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => {
+                const reference = row.original;
+                const name = reference.text || '';
+                const imageUrl = reference.media?.src || null;
+
+                return (
+                    <div className="flex items-center gap-2">
+                        {imageUrl && <img src={imageUrl} alt={name} className="h-8 w-8 rounded object-cover" />}
+                        <span>{name}</span>
+                    </div>
+                );
+            },
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => <ReferenceActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} />,
+        },
+    ];
+
+    return <DataTable columns={columns} data={references} filterColumn="text" />;
+}

--- a/resources/js/components/references/referenceForm.tsx
+++ b/resources/js/components/references/referenceForm.tsx
@@ -1,0 +1,63 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { IReference } from '@/types/reference';
+
+interface ReferenceFormProps {
+    closeDrawer?: () => void;
+    initialData?: IReference;
+}
+
+const defaultValues: IReference = {
+    text: '',
+    is_active: true,
+};
+
+export default function ReferenceForm({ closeDrawer, initialData }: ReferenceFormProps) {
+    const { t } = useTranslation();
+    const { data, setData, processing, errors, reset } = useForm<IReference>(initialData || defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        const routeUrl = initialData?.id ? route('dashboard.references.update', initialData.id) : route('dashboard.references.store');
+
+        router.visit(routeUrl, {
+            method: initialData?.id ? 'put' : 'post',
+            data: {
+                text: data.text,
+                media_id: data.media_id,
+                is_active: data.is_active ? '1' : '0',
+            },
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success(initialData?.id ? t('references.updated', 'Référence mise à jour !') : t('references.created', 'Référence créée !'));
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Label htmlFor="text">{t('Text')}</Label>
+                <Input id="text" value={data.text ?? ''} onChange={(e) => setData('text', e.target.value)} disabled={processing} />
+                <InputError message={errors.text} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="media_id">{t('Media ID')}</Label>
+                <Input id="media_id" type="number" required value={data.media_id ?? ''} onChange={(e) => setData('media_id', Number(e.target.value))} disabled={processing} />
+                <InputError message={errors.media_id} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {initialData?.id ? t('Update', 'Mettre à jour') : t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/references/referenceToolBar.tsx
+++ b/resources/js/components/references/referenceToolBar.tsx
@@ -1,0 +1,32 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface IReferenceToolBarProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function ReferenceToolBar({ FormComponent, open, setOpen }: IReferenceToolBarProps) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('References')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add reference', 'Ajouter une référence')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && <Drawer title={t('References.add', 'Ajouter une référence')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/references/index.tsx
+++ b/resources/js/pages/dashboard/references/index.tsx
@@ -1,0 +1,94 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import ReferenceForm from '@/components/references/referenceForm';
+import ReferenceToolBar from '@/components/references/referenceToolBar';
+import ReferenceDataTable from '@/components/references/referenceDataTable';
+import { IReference } from '@/types/reference';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Références',
+        href: '/dashboard/references',
+    },
+    {
+        title: 'Dashboard',
+        href: route('dashboard.index'),
+    },
+];
+
+export default function DashboardReferences() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+
+    const [references, setReferences] = useState<IReference[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<IReference | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && (data.references as any)?.data) {
+            setReferences((data.references as any).data);
+        } else if (data && Array.isArray(data.references)) {
+            setReferences(data.references as any);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.references.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('references.deleted', 'Référence supprimée'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    const handleOpenEdit = (row: IReference) => {
+        setSelected(row);
+        setOpenForm(true);
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Dashboard" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <ReferenceToolBar
+                    FormComponent={<ReferenceForm closeDrawer={() => setOpenForm(false)} initialData={selected} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete reference', 'Supprimer la référence')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer cette référence ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {references && (
+                        <ReferenceDataTable
+                            references={references}
+                            onEditRow={handleOpenEdit}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -67,3 +67,5 @@ export interface IDataWithPagination<T> {
     to: number,
     total: number
 }
+
+export * from './reference';

--- a/resources/js/types/reference.d.ts
+++ b/resources/js/types/reference.d.ts
@@ -1,0 +1,9 @@
+export interface IReference {
+    id?: number;
+    text?: string;
+    is_active: boolean;
+    media?: IMedia;
+    media_id?: number;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Private\DashboardController;
 use App\Http\Controllers\Private\FaqController;
 use App\Http\Controllers\Private\SettingController;
 use App\Http\Controllers\Private\TestimonialController;
+use App\Http\Controllers\Private\ReferenceController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 
@@ -113,5 +114,16 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::put('update/{faq}',   [FaqController::class, 'update'])->name('dashboard.faqs.update');
         Route::delete('delete/{faq}', [FaqController::class, 'destroy'])->name('dashboard.faqs.delete');
         Route::post('restore/{faq}', [FaqController::class, 'restore'])->name('dashboard.faqs.restore');
+    });
+
+    // REFERENCES
+    Route::group([
+        'prefix' => 'references',
+    ], function () {
+        Route::get('',               [ReferenceController::class, 'index'])->name('dashboard.references.index');
+        Route::post('create',        [ReferenceController::class, 'store'])->name('dashboard.references.store');
+        Route::put('update/{reference}', [ReferenceController::class, 'update'])->name('dashboard.references.update');
+        Route::delete('delete/{reference}', [ReferenceController::class, 'destroy'])->name('dashboard.references.delete');
+        Route::post('restore/{reference}', [ReferenceController::class, 'restore'])->name('dashboard.references.restore');
     });
 });


### PR DESCRIPTION
## Summary
- add Reference model and migration
- implement dashboard routes and controller
- create store/update requests and repository
- add React components and page for managing references
- export IReference type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e2a6affc8333868fcfafb2d9711b