### PR TITLE
Ajout de statistiques sur le dashboard

### DIFF
--- a/app/Http/Controllers/Private/DashboardController.php
+++ b/app/Http/Controllers/Private/DashboardController.php
@@ -69,6 +69,23 @@ class DashboardController extends PrivateAbstractController
             $chartData[] = isset($enrollmentData[$month]) ? $enrollmentData[$month] : 0;
         }
 
+        // Fetch courses created data for the current year, grouped by month
+        $courseData = Course::select(
+            DB::raw('MONTH(created_at) as month'),
+            DB::raw('COUNT(*) as count')
+        )
+            ->whereYear('created_at', $currentYear)
+            ->groupBy(DB::raw('MONTH(created_at)'))
+            ->orderBy('month')
+            ->get()
+            ->pluck('count', 'month')
+            ->toArray();
+
+        $courseChartData = [];
+        for ($month = 1; $month <= 12; $month++) {
+            $courseChartData[] = isset($courseData[$month]) ? $courseData[$month] : 0;
+        }
+
         $chart_data = [
             'enrollment_area' => [
                 'series' => [
@@ -92,8 +109,27 @@ class DashboardController extends PrivateAbstractController
                     "$currentYear-12-01T00:00:00.000Z",
                 ],
             ],
-            'doughnut' => [
-                'options' => ['red', 'blue', 'green', 'black'],
+            'course_area' => [
+                'series' => [
+                    [
+                        'name' => 'Courses',
+                        'data' => $courseChartData,
+                    ],
+                ],
+                'categories' => [
+                    "$currentYear-01-01T00:00:00.000Z",
+                    "$currentYear-02-01T00:00:00.000Z",
+                    "$currentYear-03-01T00:00:00.000Z",
+                    "$currentYear-04-01T00:00:00.000Z",
+                    "$currentYear-05-01T00:00:00.000Z",
+                    "$currentYear-06-01T00:00:00.000Z",
+                    "$currentYear-07-01T00:00:00.000Z",
+                    "$currentYear-08-01T00:00:00.000Z",
+                    "$currentYear-09-01T00:00:00.000Z",
+                    "$currentYear-10-01T00:00:00.000Z",
+                    "$currentYear-11-01T00:00:00.000Z",
+                    "$currentYear-12-01T00:00:00.000Z",
+                ],
             ],
         ];
 
@@ -106,6 +142,7 @@ class DashboardController extends PrivateAbstractController
         $data['courses'] = $courses;
         $data['enrollments'] = $enrollments;
         $data['notifications'] = $notifications;
+        $data['chart_data'] = $chart_data;
         return Inertia::render('dashboard/dashboard.home', [
             'data' => $data,
         ]);

--- a/resources/js/components/charts/EnrollmentRate.tsx
+++ b/resources/js/components/charts/EnrollmentRate.tsx
@@ -1,21 +1,27 @@
 import { CLASS_NAME } from '@/data/styles/style.constant';
 import EnrollmentRateAreaChart from './EnrollmentRateAreaChart';
+import { SharedData } from '@/types';
+import { usePage } from '@inertiajs/react';
 
 export default function EnrollmentRate() {
+    const { data } = usePage<SharedData>().props;
+    const charts = data.chart_data;
+
+    if (!charts) return null;
+
     return (
         <section className={CLASS_NAME.section}>
-            <div className="grid grid-cols-1 2xl:grid-cols-12 gap-6">
-                <div className="col-span-12 md:col-span-6 2xl:col-span-8">
-                    <div className="card-body p-0">
-                        <div className="flex items-center flex-wrap gap-2 justify-between">
-                            <h6 className="mb-2 font-bold text-lg"></h6>
-                        </div>
-
-                        <div className="mt-10">
-                            {/* <EnrollmentRateAreaChart /> */}
-                        </div>
-                    </div>
-                </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <EnrollmentRateAreaChart
+                    title="Inscriptions"
+                    series={charts.enrollment_area.series}
+                    categories={charts.enrollment_area.categories}
+                />
+                <EnrollmentRateAreaChart
+                    title="Formations"
+                    series={charts.course_area.series}
+                    categories={charts.course_area.categories}
+                />
             </div>
         </section>
     );

--- a/resources/js/components/charts/EnrollmentRateAreaChart.tsx
+++ b/resources/js/components/charts/EnrollmentRateAreaChart.tsx
@@ -2,25 +2,19 @@ import React, { Suspense, useEffect, useState } from 'react';
 import { ApexOptions } from 'apexcharts';
 import Chart from 'react-apexcharts';
 
+export interface AreaChartProps {
+    title?: string;
+    series: { name: string; data: number[] }[];
+    categories: string[];
+}
 
-const EnrollmentRateAreaChart: React.FC = () => {
+const EnrollmentRateAreaChart: React.FC<AreaChartProps> = ({ title = 'Chart', series, categories }) => {
     // Chart
     const [isChartLoaded, setChartLoaded] = useState(false);
 
     useEffect(() => {
         setChartLoaded(true);
     }, []);
-
-    const series = [
-        {
-            name: 'Trezo',
-            data: [31, 40, 28, 51, 42, 109, 100],
-        },
-        {
-            name: 'Social',
-            data: [11, 32, 45, 32, 34, 52, 41],
-        },
-    ];
 
     const options: ApexOptions = {
         chart: {
@@ -37,15 +31,7 @@ const EnrollmentRateAreaChart: React.FC = () => {
         colors: ['#605DFF', '#0f79f3'],
         xaxis: {
             type: 'datetime',
-            categories: [
-                '2018-09-19T00:00:00.000Z',
-                '2018-09-19T01:30:00.000Z',
-                '2018-09-19T02:30:00.000Z',
-                '2018-09-19T03:30:00.000Z',
-                '2018-09-19T04:30:00.000Z',
-                '2018-09-19T05:30:00.000Z',
-                '2018-09-19T06:30:00.000Z',
-            ],
+            categories,
             axisTicks: {
                 show: false,
                 color: '#ECEEF2',
@@ -117,7 +103,7 @@ const EnrollmentRateAreaChart: React.FC = () => {
             <div className="trezo-card bg-white dark:bg-[#0c1427] p-[20px] md:p-[25px] rounded-md">
                 <div className="trezo-card-header mb-[20px] md:mb-[25px] flex items-center justify-between">
                     <div className="trezo-card-title">
-                        <h5 className="!mb-0">Spline Area Chart</h5>
+                        <h5 className="!mb-0">{title}</h5>
                     </div>
                 </div>
                 <div className="trezo-card-content">

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -3,6 +3,11 @@ import { IBlog, IBlogCategory } from "./blogs";
 import { ITestimonial } from "./testimonial";
 import { IFaq } from "./faq";
 
+export interface IChartData {
+    series: { name: string; data: number[] }[];
+    categories: string[];
+}
+
 
 export enum PeriodicityUnitEnum {
     DAY = 'DAY',
@@ -264,4 +269,9 @@ export interface ICustomSharedData {
 
     testimonials?: IDataWithPagination<ITestimonial>
     faqs?: IFaq[]
+
+    chart_data?: {
+        enrollment_area: IChartData;
+        course_area: IChartData;
+    }
 }


### PR DESCRIPTION
## Summary
- ajoute des données de graphes côté serveur
- crée un composant de graphique générique et l’utilise dans le dashboard
- expose les graphes des formations et inscriptions
- met à jour les types partagés

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: numerous type errors and missing modules)*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e5a382448333ae7884eb71846670