### PR TITLE
Add partner management system

### DIFF
--- a/app/Http/Controllers/Private/CourseController.php
+++ b/app/Http/Controllers/Private/CourseController.php
@@ -16,6 +16,7 @@ use App\Repositories\CourseRepository;
 use App\Repositories\InstructorRepository;
 use App\Repositories\NotificationInstanceRepository;
 use App\Repositories\NotificationRepository;
+use App\Repositories\PartnerRepository;
 use App\Repositories\UserRepository;
 use App\Services\Notification\CourseStoreNotificationService;
 use Illuminate\Http\Request;
@@ -80,6 +81,7 @@ class CourseController extends Controller
     {
         // $categories = CategoryRepository::findAll();
         $categories = CategoryRepository::getRecursiveTree(false);
+        $partners = PartnerRepository::query()->where('is_active', true)->get();
         // dd($categories);
         $course = null;
         if ($slug) {
@@ -89,6 +91,7 @@ class CourseController extends Controller
         $data = [
             'course'                  => $course,
             'categories_with_courses' => $categories,
+            'partners'               => $partners,
         ];
 
         return Inertia::render('dashboard/courses/course-create', [

--- a/app/Http/Controllers/Private/PartnerController.php
+++ b/app/Http/Controllers/Private/PartnerController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PartnerStoreRequest;
+use App\Http\Requests\PartnerUpdateRequest;
+use App\Models\Partner;
+use App\Repositories\PartnerRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class PartnerController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->search ? strtolower($request->search) : null;
+
+        $partners = PartnerRepository::query()
+            ->when($search, function ($query) use ($search) {
+                $query->where('name', 'like', '%' . $search . '%');
+            })
+            ->with('media')
+            ->withTrashed()
+            ->latest('id')
+            ->paginate(15)
+            ->withQueryString();
+
+        $data = [
+            'partners' => $partners,
+        ];
+
+        return Inertia::render('dashboard/partners/index', [
+            'data' => $data,
+        ]);
+    }
+
+    public function store(PartnerStoreRequest $request)
+    {
+        if (app()->isLocal()) {
+            return to_route('dashboard.partners.index')->with('error', 'Partner not created in demo mode');
+        }
+
+        PartnerRepository::storeByRequest($request);
+
+        return to_route('dashboard.partners.index')->withSuccess('Partner created successfully.');
+    }
+
+    public function update(PartnerUpdateRequest $request, Partner $partner)
+    {
+        PartnerRepository::updateByRequest($request, $partner);
+        return to_route('dashboard.partners.index')->withSuccess('Partner updated successfully.');
+    }
+
+    public function destroy(Partner $partner)
+    {
+        $partner->delete();
+        $partner->is_active = false;
+        $partner->save();
+        return to_route('dashboard.partners.index')->withSuccess('Partner deleted successfully.');
+    }
+
+    public function restore($partner)
+    {
+        PartnerRepository::query()->withTrashed()->find($partner)->restore();
+        return to_route('dashboard.partners.index')->withSuccess('Partner restored successfully.');
+    }
+}

--- a/app/Http/Requests/CourseStoreRequest.php
+++ b/app/Http/Requests/CourseStoreRequest.php
@@ -31,6 +31,8 @@ class CourseStoreRequest extends FormRequest
             'gallery.*'            => 'file|mimes:jpeg,png,jpg,mp4,mpeg|max:1048576',
             'description'           => 'json|min:1',
             'is_published'          => 'boolean',
+            'partner_ids'           => 'sometimes|array',
+            'partner_ids.*'         => 'exists:partners,id',
             'regular_price'         => 'numeric|min:' . ((float) config('app.minimum_amount')),
             'price' => [
                 'nullable',

--- a/app/Http/Requests/CourseUpdateRequest.php
+++ b/app/Http/Requests/CourseUpdateRequest.php
@@ -31,6 +31,8 @@ class CourseUpdateRequest extends FormRequest
             'description'           => 'required|array|min:1',
             'description.*.heading' => 'required|string',
             'description.*.body'    => 'required|string',
+            'partner_ids'           => 'sometimes|array',
+            'partner_ids.*'         => 'exists:partners,id',
             'regular_price'         => 'required|numeric|min:' . ((float) config('app.minimum_amount')),
             'instructor_id'         => 'exists:instructors,id',
             'is_active'             => 'nullable',

--- a/app/Http/Requests/PartnerStoreRequest.php
+++ b/app/Http/Requests/PartnerStoreRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PartnerStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string',
+            'link' => 'nullable|url',
+            'media_id' => 'required|exists:media,id',
+        ];
+    }
+}

--- a/app/Http/Requests/PartnerUpdateRequest.php
+++ b/app/Http/Requests/PartnerUpdateRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PartnerUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string',
+            'link' => 'nullable|url',
+            'media_id' => 'nullable|exists:media,id',
+        ];
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
+use App\Models\Partner;
 
 class Course extends Model
 {
@@ -106,6 +107,11 @@ class Course extends Model
     public function favouriteUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'user_courses');
+    }
+
+    public function partners(): BelongsToMany
+    {
+        return $this->belongsToMany(Partner::class, 'course_partner');
     }
 
     // public function chapters(): HasMany

--- a/app/Models/Partner.php
+++ b/app/Models/Partner.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
+
+class Partner extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $guarded = ['id'];
+
+    public function media(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'media_id');
+    }
+
+    public function mediaPath(): Attribute
+    {
+        $media = null;
+        if ($this->media && Storage::exists($this->media->src)) {
+            $media = Storage::url($this->media->src);
+        }
+
+        return Attribute::make(
+            get: fn() => $media,
+        );
+    }
+
+    public function courses(): BelongsToMany
+    {
+        return $this->belongsToMany(Course::class, 'course_partner');
+    }
+}

--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -264,6 +264,10 @@ class CourseRepository extends Repository
             $course->gallery()->attach($galleryIds);
         }
 
+        if ($request->partner_ids) {
+            $course->partners()->sync($request->partner_ids);
+        }
+
         return $course;
     }
 
@@ -320,6 +324,10 @@ class CourseRepository extends Repository
                 );
                 $course->gallery()->attach($media->id);
             }
+        }
+
+        if ($request->partner_ids) {
+            $course->partners()->sync($request->partner_ids);
         }
 
         return self::update($course, [

--- a/app/Repositories/PartnerRepository.php
+++ b/app/Repositories/PartnerRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\Partner;
+
+class PartnerRepository extends Repository
+{
+    public static function model()
+    {
+        return Partner::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'name' => $request->name,
+            'link' => $request->link,
+            'media_id' => $request->media_id,
+            'is_active' => $request->has('is_active') ? true : false,
+        ]);
+    }
+
+    public static function updateByRequest($request, Partner $partner)
+    {
+        return self::update($partner, [
+            'name' => $request->name ?? $partner->name,
+            'link' => $request->link ?? $partner->link,
+            'media_id' => $request->media_id ?? $partner->media_id,
+            'is_active' => $request->has('is_active') ? true : $partner->is_active,
+        ]);
+    }
+}

--- a/database/migrations/2025_07_12_042000_create_partners_table.php
+++ b/database/migrations/2025_07_12_042000_create_partners_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\Media;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('partners', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Media::class)->nullable()->constrained('media')->nullOnDelete();
+            $table->string('name');
+            $table->string('link')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partners');
+    }
+};

--- a/database/migrations/2025_07_12_042500_create_course_partner_table.php
+++ b/database/migrations/2025_07_12_042500_create_course_partner_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('course_partner', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained('courses')->cascadeOnDelete();
+            $table->foreignId('partner_id')->constrained('partners')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('course_partner');
+    }
+};

--- a/resources/js/components/courses/form/course.form.util.ts
+++ b/resources/js/components/courses/form/course.form.util.ts
@@ -37,6 +37,8 @@ export type ICourseRequest = {
 
     image: string;
 
+    partner_ids?: number[];
+
     is_published?: boolean; // Indicate if the course is published or a draft
 };
 
@@ -64,6 +66,8 @@ export type ICourseForm = {
     image: string;
 
     is_featured: boolean;
+
+    partner_ids?: number[];
 
     // description: string;
     /**
@@ -150,6 +154,7 @@ export const COURSE_DEFAULT_VALUES: ICourseForm = {
     content: '',
 
     is_featured: false,
+    partner_ids: [],
 };
 
 
@@ -197,6 +202,7 @@ export const createPayload = (data: ICourseForm, draft: boolean): ICourseRequest
             title: data.title || '',
             attachment: data.attachment || '',
             is_published: !draft, // If draft is true, is_published should be false
+            partner_ids: data.partner_ids,
         };
 
         console.log('[CREATE_PAYLOAD]', payload);

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -9,11 +9,13 @@ import { Button } from '@/components/ui/button/button';
 
 import { SharedData } from '@/types';
 import { ICourse, ICourseCategory } from '@/types/course';
+import { IPartner } from '@/types/partner';
 import 'react-quill/dist/quill.snow.css';
 import RichTextQuill from '../../ui/form/RichTextQuill';
 import { Skeleton } from '../../ui/skeleton';
 import CourseAdditionnalForm from './course-additionnal.form';
 import CourseBasicInfoForm from './course-basic-info.form';
+import Drawer from '@/components/ui/drawer';
 
 import { ROUTE_MAP } from '@/utils/route.util';
 import axios from 'axios';
@@ -53,6 +55,9 @@ function CourseForm({ course }: ICourseFormProps) {
 
     const [openIndex, setOpenIndex] = useState<number | null>(0);
     const [categories, setCategories] = useState<ICourseCategory[]>([]);
+    const [partners, setPartners] = useState<IPartner[]>([]);
+    const [selectedPartners, setSelectedPartners] = useState<number[]>([]);
+    const [openPartnerDrawer, setOpenPartnerDrawer] = useState(false);
     const [thumbnail, setThumbnail] = useState<File | null>(null);
     const [videoFile, setVideoFile] = useState<File | null>(null);
     const [galleryFiles, setGalleryFiles] = useState<FileList | null>(null);
@@ -84,6 +89,8 @@ function CourseForm({ course }: ICourseFormProps) {
         setData('author', course.author || '');
         setData('image', course.image || '');
         setData('title', course.title || '');
+        setData('partner_ids', course.partners ? course.partners.map((p) => p.id!) : []);
+        setSelectedPartners(course.partners ? course.partners.map((p) => p.id!) : []);
 
         // setData('description', course.description || '');
         if (course.description) {
@@ -150,6 +157,9 @@ function CourseForm({ course }: ICourseFormProps) {
             setCategories(sharedData.categories_with_courses);
         } else {
             setCategories([]);
+        }
+        if (sharedData && (sharedData as any).partners) {
+            setPartners((sharedData as any).partners);
         }
     }, [sharedData]);
 
@@ -289,6 +299,9 @@ function CourseForm({ course }: ICourseFormProps) {
 
                 <div className="col-span-1 md:col-span-1">
                     <div className="grid grid-cols-1 gap-4">
+                        <Button type="button" onClick={() => setOpenPartnerDrawer(true)} className="mt-2 bg-blue-400 hover:bg-blue-500" disabled={processing}>
+                            {t('courses.partners', 'Associer des partenaires')}
+                        </Button>
                         <Button
                             type="button"
                             onClick={() => router.visit(route('dashboard.course.index'))}
@@ -316,6 +329,34 @@ function CourseForm({ course }: ICourseFormProps) {
                 </div>
             </div>
         </form>
+        <Drawer
+            title={t('courses.partners', 'Associer des partenaires')}
+            open={openPartnerDrawer}
+            setOpen={setOpenPartnerDrawer}
+            component={(
+                <div className="space-y-2">
+                    {partners.map((p) => (
+                        <label key={p.id} className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={selectedPartners.includes(p.id!)}
+                                onChange={(e) => {
+                                    let updated = [...selectedPartners];
+                                    if (e.target.checked) {
+                                        updated.push(p.id!);
+                                    } else {
+                                        updated = updated.filter((id) => id !== p.id);
+                                    }
+                                    setSelectedPartners(updated);
+                                    setData('partner_ids', updated);
+                                }}
+                            />
+                            <span>{p.name}</span>
+                        </label>
+                    ))}
+                </div>
+            )}
+        />
     );
 }
 

--- a/resources/js/components/partners/partnerActionBtn.tsx
+++ b/resources/js/components/partners/partnerActionBtn.tsx
@@ -1,0 +1,27 @@
+import { IPartner } from '@/types/partner';
+import { SquarePen, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+
+interface IPartnerActionBtnProps {
+    row: {
+        original: IPartner;
+    };
+    onEdit?: (row: IPartner) => void;
+    onDelete?: (row: IPartner) => void;
+}
+
+export default function PartnerActionBtn({ row, onEdit, onDelete }: IPartnerActionBtnProps) {
+    return (
+        <div className="flex space-x-2">
+            <Button variant={'ghost'} size="icon" onClick={() => onEdit?.(row.original)}>
+                <SquarePen className="h-4 w-4" />
+                <span className="sr-only">Modifier</span>
+            </Button>
+
+            <Button variant={'ghost'} size="icon" onClick={() => onDelete?.(row.original)}>
+                <Trash2 className="text-red h-4 w-4" style={{ color: 'red' }} />
+                <span className="sr-only">Supprimer</span>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/partners/partnerDataTable.tsx
+++ b/resources/js/components/partners/partnerDataTable.tsx
@@ -1,0 +1,61 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import PartnerActionBtn from './partnerActionBtn';
+import { IPartner } from '@/types/partner';
+
+interface PartnerDataTableProps {
+    partners: IPartner[];
+    onEditRow?: (row: IPartner) => void;
+    onDeleteRow?: (row: IPartner) => void;
+}
+
+export default function PartnerDataTable({ partners, onEditRow, onDeleteRow }: PartnerDataTableProps) {
+    const columns: ColumnDef<IPartner>[] = [
+        {
+            id: 'select',
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+                    onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                    aria-label="Select all"
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+        },
+        {
+            accessorKey: 'name',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Nom
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => {
+                const partner = row.original;
+                const name = partner.name || '';
+                const imageUrl = partner.media?.src || null;
+
+                return (
+                    <div className="flex items-center gap-2">
+                        {imageUrl && <img src={imageUrl} alt={name} className="h-8 w-8 rounded object-cover" />}
+                        <span>{name}</span>
+                    </div>
+                );
+            },
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => <PartnerActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} />,
+        },
+    ];
+
+    return <DataTable columns={columns} data={partners} filterColumn="name" />;
+}

--- a/resources/js/components/partners/partnerForm.tsx
+++ b/resources/js/components/partners/partnerForm.tsx
@@ -1,0 +1,70 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { IPartner } from '@/types/partner';
+
+interface PartnerFormProps {
+    closeDrawer?: () => void;
+    initialData?: IPartner;
+}
+
+const defaultValues: IPartner = {
+    name: '',
+    link: '',
+    is_active: true,
+};
+
+export default function PartnerForm({ closeDrawer, initialData }: PartnerFormProps) {
+    const { t } = useTranslation();
+    const { data, setData, processing, errors, reset } = useForm<IPartner>(initialData || defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        const routeUrl = initialData?.id ? route('dashboard.partners.update', initialData.id) : route('dashboard.partners.store');
+
+        router.visit(routeUrl, {
+            method: initialData?.id ? 'put' : 'post',
+            data: {
+                name: data.name,
+                link: data.link,
+                media_id: data.media_id,
+                is_active: data.is_active ? '1' : '0',
+            },
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success(initialData?.id ? t('partners.updated', 'Partenaire mis à jour !') : t('partners.created', 'Partenaire créé !'));
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Label htmlFor="name">{t('Name', 'Nom')}</Label>
+                <Input id="name" required value={data.name ?? ''} onChange={(e) => setData('name', e.target.value)} disabled={processing} />
+                <InputError message={errors.name} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="link">{t('Link', 'Lien')}</Label>
+                <Input id="link" value={data.link ?? ''} onChange={(e) => setData('link', e.target.value)} disabled={processing} />
+                <InputError message={errors.link} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="media_id">{t('Media ID')}</Label>
+                <Input id="media_id" type="number" required value={data.media_id ?? ''} onChange={(e) => setData('media_id', Number(e.target.value))} disabled={processing} />
+                <InputError message={errors.media_id} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {initialData?.id ? t('Update', 'Mettre à jour') : t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/partners/partnerToolBar.tsx
+++ b/resources/js/components/partners/partnerToolBar.tsx
@@ -1,0 +1,32 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface IPartnerToolBarProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function PartnerToolBar({ FormComponent, open, setOpen }: IPartnerToolBarProps) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('Partners')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add partner', 'Ajouter un partenaire')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && <Drawer title={t('Partners.add', 'Ajouter un partenaire')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/partners/index.tsx
+++ b/resources/js/pages/dashboard/partners/index.tsx
@@ -1,0 +1,94 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import PartnerForm from '@/components/partners/partnerForm';
+import PartnerToolBar from '@/components/partners/partnerToolBar';
+import PartnerDataTable from '@/components/partners/partnerDataTable';
+import { IPartner } from '@/types/partner';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Partenaires',
+        href: '/dashboard/partners',
+    },
+    {
+        title: 'Dashboard',
+        href: route('dashboard.index'),
+    },
+];
+
+export default function DashboardPartners() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+
+    const [partners, setPartners] = useState<IPartner[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<IPartner | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && (data.partners as any)?.data) {
+            setPartners((data.partners as any).data);
+        } else if (data && Array.isArray(data.partners)) {
+            setPartners(data.partners as any);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.partners.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('partners.deleted', 'Partenaire supprimé'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    const handleOpenEdit = (row: IPartner) => {
+        setSelected(row);
+        setOpenForm(true);
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Dashboard" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <PartnerToolBar
+                    FormComponent={<PartnerForm closeDrawer={() => setOpenForm(false)} initialData={selected} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete partner', 'Supprimer le partenaire')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer ce partenaire ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {partners && (
+                        <PartnerDataTable
+                            partners={partners}
+                            onEditRow={handleOpenEdit}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -2,6 +2,7 @@ import { IDataWithPagination } from ".";
 import { IBlog, IBlogCategory } from "./blogs";
 import { ITestimonial } from "./testimonial";
 import { IFaq } from "./faq";
+import { IPartner } from "./partner";
 
 
 export enum PeriodicityUnitEnum {
@@ -112,6 +113,7 @@ export interface ICourse {
     media?: IMedia[];
     gallery?: IMedia[];
     course_sessions?: ICourseSession[];
+    partners?: IPartner[];
 
 }
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -69,3 +69,4 @@ export interface IDataWithPagination<T> {
 }
 
 export * from './reference';
+export * from './partner';

--- a/resources/js/types/partner.d.ts
+++ b/resources/js/types/partner.d.ts
@@ -1,0 +1,10 @@
+export interface IPartner {
+    id?: number;
+    name: string;
+    link?: string;
+    is_active: boolean;
+    media?: IMedia;
+    media_id?: number;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Private\FaqController;
 use App\Http\Controllers\Private\SettingController;
 use App\Http\Controllers\Private\TestimonialController;
 use App\Http\Controllers\Private\ReferenceController;
+use App\Http\Controllers\Private\PartnerController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 
@@ -125,5 +126,16 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::put('update/{reference}', [ReferenceController::class, 'update'])->name('dashboard.references.update');
         Route::delete('delete/{reference}', [ReferenceController::class, 'destroy'])->name('dashboard.references.delete');
         Route::post('restore/{reference}', [ReferenceController::class, 'restore'])->name('dashboard.references.restore');
+    });
+
+    // PARTNERS
+    Route::group([
+        'prefix' => 'partners',
+    ], function () {
+        Route::get('',               [PartnerController::class, 'index'])->name('dashboard.partners.index');
+        Route::post('create',        [PartnerController::class, 'store'])->name('dashboard.partners.store');
+        Route::put('update/{partner}', [PartnerController::class, 'update'])->name('dashboard.partners.update');
+        Route::delete('delete/{partner}', [PartnerController::class, 'destroy'])->name('dashboard.partners.delete');
+        Route::post('restore/{partner}', [PartnerController::class, 'restore'])->name('dashboard.partners.restore');
     });
 });


### PR DESCRIPTION
## Summary
- create Partner model, controller, requests and repository
- add migrations for partners and course-partner pivot
- expose partner CRUD routes in dashboard
- integrate partners with course form including drawer to select partners
- add frontend pages and components for partner management

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6871e61c1bd08333b82676c6a47e4e0e