### PR TITLE
Add logos to course editing

### DIFF
--- a/app/Http/Requests/CourseStoreRequest.php
+++ b/app/Http/Requests/CourseStoreRequest.php
@@ -26,6 +26,8 @@ class CourseStoreRequest extends FormRequest
             'title'                 => 'required|min:2|max:500',
             'excerpt'               => 'required|string|min:2|max:5000',
             'media'                 => 'image|mimes:jpeg,png,jpg|max:2048',
+            'logo'                  => 'image|mimes:jpeg,png,jpg|max:2048',
+            'organization_logo'     => 'image|mimes:jpeg,png,jpg|max:2048',
             'video'                 => 'file|mimes:mp4,mpeg|max:1048576',
             'gallery'               => 'sometimes|array',
             'gallery.*'            => 'file|mimes:jpeg,png,jpg,mp4,mpeg|max:1048576',

--- a/app/Http/Requests/CourseUpdateRequest.php
+++ b/app/Http/Requests/CourseUpdateRequest.php
@@ -25,6 +25,8 @@ class CourseUpdateRequest extends FormRequest
             'category_id'           => 'exists:categories,id',
             'title'                 => 'string|min:5|max:500',
             'media'                 => "image|mimes:jpeg,png,jpg|max:10240",
+            'logo'                  => 'image|mimes:jpeg,png,jpg|max:10240',
+            'organization_logo'     => 'image|mimes:jpeg,png,jpg|max:10240',
             'video'                 => 'file|mimes:mp4,mpeg|max:1048576',
             'gallery'               => 'sometimes|array',
             'gallery.*'            => 'file|mimes:jpeg,png,jpg,mp4,mpeg|max:1048576',

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -104,6 +104,42 @@ class Course extends Model
         );
     }
 
+    public function logo(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'logo_id');
+    }
+
+    public function logoPath(): Attribute
+    {
+        $logo = null;
+
+        if ($this->logo && Storage::exists($this->logo->src)) {
+            $logo = Storage::url($this->logo->src);
+        }
+
+        return Attribute::make(
+            get: fn() => $logo,
+        );
+    }
+
+    public function organizationLogo(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'organization_logo_id');
+    }
+
+    public function organizationLogoPath(): Attribute
+    {
+        $logo = null;
+
+        if ($this->organizationLogo && Storage::exists($this->organizationLogo->src)) {
+            $logo = Storage::url($this->organizationLogo->src);
+        }
+
+        return Attribute::make(
+            get: fn() => $logo,
+        );
+    }
+
     public function favouriteUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'user_courses');

--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -25,7 +25,9 @@ class CourseRepository extends Repository
                     // 'nextSession',
                     'instructor.user',
                     'media',
-                    'video'
+                    'video',
+                    'logo',
+                    'organizationLogo'
                 ]);
         } catch (\Exception $e) {
             throw new \Exception('Error initializing course query: ' . $e->getMessage());
@@ -201,6 +203,18 @@ class CourseRepository extends Repository
             MediaTypeEnum::IMAGE
         ) : null;
 
+        $logo = $request->hasFile('logo') ? MediaRepository::storeByRequest(
+            $request->file('logo'),
+            'course/logo',
+            MediaTypeEnum::IMAGE
+        ) : null;
+
+        $organizationLogo = $request->hasFile('organization_logo') ? MediaRepository::storeByRequest(
+            $request->file('organization_logo'),
+            'course/organization-logo',
+            MediaTypeEnum::IMAGE
+        ) : null;
+
         $video = $request->hasFile('video') ? MediaRepository::storeByRequest(
             $request->file('video'),
             'course/video',
@@ -227,6 +241,8 @@ class CourseRepository extends Repository
             'title'         => $request->title,
             'slug'          => str($request->title)->slug(),
             'media_id'      => $media ? $media->id : null,
+            'logo_id'       => $logo ? $logo->id : null,
+            'organization_logo_id' => $organizationLogo ? $organizationLogo->id : null,
             'video_id'      => $video ? $video->id : null,
             'description'   => $request->description ?? "", // json_encode($request->description)
             'regular_price' => $request->regular_price,
@@ -300,6 +316,26 @@ class CourseRepository extends Repository
             );
         }
 
+        $logo = $course->logo;
+        if ($request->hasFile('logo')) {
+            $logo = MediaRepository::updateOrCreateByRequest(
+                $request->file('logo'),
+                'course/logo',
+                $logo,
+                MediaTypeEnum::IMAGE
+            );
+        }
+
+        $organizationLogo = $course->organizationLogo;
+        if ($request->hasFile('organization_logo')) {
+            $organizationLogo = MediaRepository::updateOrCreateByRequest(
+                $request->file('organization_logo'),
+                'course/organization-logo',
+                $organizationLogo,
+                MediaTypeEnum::IMAGE
+            );
+        }
+
         if ($course->video) {
             $video = $request->hasFile('video') ? MediaRepository::updateByRequest(
                 $request->file('video'),
@@ -335,6 +371,8 @@ class CourseRepository extends Repository
             'title'         => $request->title ?? $course->title,
             'slug'          => str($request->title)->slug(),
             'media_id'      => $media ? $media->id : $course->media->id,
+            'logo_id'       => $logo ? $logo->id : $course->logo_id,
+            'organization_logo_id' => $organizationLogo ? $organizationLogo->id : $course->organization_logo_id,
             'video_id'      => $video ? $video->id : null,
             'description'   => json_encode($request->description) ?? $course->description,
             'regular_price' => $request->regular_price ?? null,

--- a/database/migrations/2025_07_12_043000_add_logo_columns_to_courses_table.php
+++ b/database/migrations/2025_07_12_043000_add_logo_columns_to_courses_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\Media;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->foreignIdFor(Media::class, 'logo_id')->nullable()->after('media_id')->constrained('media')->nullOnDelete();
+            $table->foreignIdFor(Media::class, 'organization_logo_id')->nullable()->after('logo_id')->constrained('media')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropForeign(['logo_id']);
+            $table->dropColumn('logo_id');
+            $table->dropForeign(['organization_logo_id']);
+            $table->dropColumn('organization_logo_id');
+        });
+    }
+};

--- a/resources/js/components/courses/form/course-basic-info.form.tsx
+++ b/resources/js/components/courses/form/course-basic-info.form.tsx
@@ -24,11 +24,13 @@ interface CourseBasicInfoFormProps {
     errors: Record<string, string>;
     categories: ICourseCategory[];
     onThumbnailChange?: (file: File | null) => void;
+    onLogoChange?: (file: File | null) => void;
+    onOrgLogoChange?: (file: File | null) => void;
     onVideoChange?: (file: File | null) => void;
     onGalleryChange?: (files: FileList | null) => void;
 }
 
-export default function CourseBasicInfoForm({ fieldsetClasses, data, setData, processing, errors, categories, onThumbnailChange, onVideoChange, onGalleryChange }: CourseBasicInfoFormProps) {
+export default function CourseBasicInfoForm({ fieldsetClasses, data, setData, processing, errors, categories, onThumbnailChange, onLogoChange, onOrgLogoChange, onVideoChange, onGalleryChange }: CourseBasicInfoFormProps) {
     const { t } = useTranslation();
 
     const category_list = (): ISelectItem[] => {
@@ -121,6 +123,16 @@ export default function CourseBasicInfoForm({ fieldsetClasses, data, setData, pr
                         <Label htmlFor="thumbnail">{t('courses.thumbnail', 'Image de mise en avant')}</Label>
                         <InputFile id="thumbnail" onFilesChange={(files) => onThumbnailChange?.(files ? files[0] : null)} accept="image/*" multiple={false} disabled={processing} />
                         <InputError message={errors.media} />
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="logo">Logo de la formation</Label>
+                        <InputFile id="logo" onFilesChange={(files) => onLogoChange?.(files ? files[0] : null)} accept="image/*" multiple={false} disabled={processing} />
+                        <InputError message={errors.logo} />
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="organization_logo">Logo de l'organisme</Label>
+                        <InputFile id="organization_logo" onFilesChange={(files) => onOrgLogoChange?.(files ? files[0] : null)} accept="image/*" multiple={false} disabled={processing} />
+                        <InputError message={errors.organization_logo} />
                     </div>
                     <div className="grid gap-2">
                         <Label htmlFor="video">{t('courses.video', 'Vidéo')}</Label>

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -59,6 +59,8 @@ function CourseForm({ course }: ICourseFormProps) {
     const [selectedPartners, setSelectedPartners] = useState<number[]>([]);
     const [openPartnerDrawer, setOpenPartnerDrawer] = useState(false);
     const [thumbnail, setThumbnail] = useState<File | null>(null);
+    const [logoFile, setLogoFile] = useState<File | null>(null);
+    const [orgLogoFile, setOrgLogoFile] = useState<File | null>(null);
     const [videoFile, setVideoFile] = useState<File | null>(null);
     const [galleryFiles, setGalleryFiles] = useState<FileList | null>(null);
 
@@ -126,6 +128,8 @@ function CourseForm({ course }: ICourseFormProps) {
         });
 
         if (thumbnail) formData.append('media', thumbnail);
+        if (logoFile) formData.append('logo', logoFile);
+        if (orgLogoFile) formData.append('organization_logo', orgLogoFile);
         if (videoFile) formData.append('video', videoFile);
         if (galleryFiles) Array.from(galleryFiles).forEach((file) => formData.append('gallery[]', file));
         if (data?.id) formData.append('_method', 'PUT');
@@ -212,6 +216,8 @@ function CourseForm({ course }: ICourseFormProps) {
                                                 processing={processing}
                                                 errors={errors}
                                                 onThumbnailChange={setThumbnail}
+                                                onLogoChange={setLogoFile}
+                                                onOrgLogoChange={setOrgLogoFile}
                                                 onVideoChange={setVideoFile}
                                                 onGalleryChange={setGalleryFiles}
                                             />

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -116,6 +116,8 @@ export interface ICourse {
     description: ICourseDescription;
     categories?: ICourseCategory[];
     media?: IMedia[];
+    logo?: IMedia;
+    organization_logo?: IMedia;
     gallery?: IMedia[];
     course_sessions?: ICourseSession[];
     partners?: IPartner[];


### PR DESCRIPTION
## Summary
- allow storing course and organization logos via migration
- extend Course model for logo relationships
- support logo media in repository and validation
- add logo upload fields to course basic info form
- wire logo state handling in course edit form
- expose logo fields in course types

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `composer install` *(fails: missing ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_6871eb7d52f08333857dc905dcc86cd0