### PR TITLE
Fix settings navigation

### DIFF
--- a/resources/js/layouts/dashboard/layout.tsx
+++ b/resources/js/layouts/dashboard/layout.tsx
@@ -6,28 +6,20 @@ import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
 import { type PropsWithChildren } from 'react';
 
-const topSidebarNavItems: NavItem[] = [
-    {
-        title: 'Configuration',
-        href: '/settings',
-        icon: null,
-    },
-];
-
 const bottomSidebarNavItems: NavItem[] = [
     {
         title: 'Profile',
-        href: '/settings/profile',
+        href: '/dashboard/settings/profile',
         icon: null,
     },
     {
         title: 'Password',
-        href: '/settings/password',
+        href: '/dashboard/settings/password',
         icon: null,
     },
     {
         title: 'Appearance',
-        href: '/settings/appearance',
+        href: '/dashboard/settings/appearance',
         icon: null,
     },
 ];
@@ -46,25 +38,6 @@ export default function SettingsLayout({ children }: PropsWithChildren) {
 
             <div className="flex flex-col space-y-8 lg:flex-row lg:space-y-0 lg:space-x-12">
                 <aside className="flex w-full max-w-xl flex-col lg:w-48">
-                    <nav className="flex flex-col space-y-1 space-x-0">
-                        {topSidebarNavItems.map((item, index) => (
-                            <Button
-                                key={`${item.href}-${index}`}
-                                size="sm"
-                                variant="ghost"
-                                asChild
-                                className={cn('w-full justify-start', {
-                                    'bg-muted': currentPath === item.href,
-                                })}
-                            >
-                                <Link href={item.href} prefetch>
-                                    {item.title}
-                                </Link>
-                            </Button>
-                        ))}
-                    </nav>
-
-                    <hr className="my-6" />
                     <nav className="flex flex-col space-y-1 space-x-0">
                         {bottomSidebarNavItems.map((item, index) => (
                             <Button


### PR DESCRIPTION
## Summary
- remove unused configuration tab from dashboard settings sidebar
- correct settings links to include `/dashboard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871ec85d0188333a64feca3a31b844c