### PR TITLE
Add basic controller tests

### DIFF
--- a/tests/Feature/ContactUsControllerTest.php
+++ b/tests/Feature/ContactUsControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+test('contact page is accessible', function () {
+    $this->get(route('contact'))
+        ->assertOk();
+});
+
+test('contact form submits successfully', function () {
+    $payload = [
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'email' => 'john@example.com',
+        'phone' => '1234567890',
+        'subject' => 'Test',
+        'message' => 'Hello world',
+    ];
+
+    $this->post(route('contact.post'), $payload)
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+        ]);
+});
+

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -9,6 +9,7 @@ test('guests are redirected to the login page', function () {
 // TODO : Uncomment this test
 // test('authenticated users can visit the dashboard', function () {
 //     $this->actingAs($user = User::factory()->create());
-
+//
 //     $this->get('/dashboard')->assertOk();
 // });
+

--- a/tests/Unit/ControllersExistenceTest.php
+++ b/tests/Unit/ControllersExistenceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+it('all controller classes are loadable', function () {
+    $controllerFiles = File::allFiles(app_path('Http/Controllers'));
+    foreach ($controllerFiles as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $relative = $file->getRelativePathname();
+        $class = 'App\\Http\\Controllers\\' . Str::replaceLast('.php', '', str_replace('/', '\\', $relative));
+        expect(class_exists($class))->toBeTrue();
+    }
+});
+


### PR DESCRIPTION
## Summary
- add a test ensuring that every controller class can be loaded
- test contact page availability and submission
- clean up DashboardTest

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6871f23eee588333847a79d92c7d0844