### PR TITLE
Add logos and partner section to course detail

### DIFF
--- a/resources/js/components/courses/detail/CourseDetail.tsx
+++ b/resources/js/components/courses/detail/CourseDetail.tsx
@@ -6,6 +6,7 @@ import CourseDetailAccordion from './CourseDetailAccordion';
 import CouseDetailMedia from './CouseDetailMedia';
 import CourseDetailChooseSection from './partial/CourseDetailChooseSection';
 import CourseDetailOverview from './partial/CourseDetailOverview';
+import CoursePartners from './CoursePartners';
 
 const email: string = 'info@ecoletestpro.com';
 
@@ -38,7 +39,25 @@ const CourseDetail: React.FC<CourseDetailProps> = ({ course }) => {
     return (
         <section className={`${CLASS_NAME.section} ${CLASS_NAME.sectionContentPadding}`}>
             <div className="container mx-auto">
-                <h1 className="text-2xl font-bold mb-6 text-black dark:text-white">{course.title}</h1>
+                <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">{course.title}</h1>
+                {(course.logo || course.organization_logo) && (
+                    <div className="mb-6 flex items-center gap-4">
+                        {course.logo && (
+                            <img
+                                src={course.logo.src}
+                                alt={`${course.title} logo`}
+                                className="h-16 w-auto object-contain"
+                            />
+                        )}
+                        {course.organization_logo && (
+                            <img
+                                src={course.organization_logo.src}
+                                alt="Organization logo"
+                                className="h-16 w-auto object-contain"
+                            />
+                        )}
+                    </div>
+                )}
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div className="toc-accordion col-span-1 md:col-span-2" id="tablesOfContentAccordion">
@@ -176,6 +195,9 @@ const CourseDetail: React.FC<CourseDetailProps> = ({ course }) => {
                                 <CourseDetailChooseSection course={course} />
                             </div>
                         </div>
+                    </div>
+                    <div className="col-span-1 md:col-span-3">
+                        <CoursePartners partners={course.partners} />
                     </div>
                 </div>
             </div>

--- a/resources/js/components/courses/detail/CoursePartners.tsx
+++ b/resources/js/components/courses/detail/CoursePartners.tsx
@@ -1,0 +1,37 @@
+import { IPartner } from '@/types/partner';
+
+interface CoursePartnersProps {
+    partners?: IPartner[];
+}
+
+export default function CoursePartners({ partners }: CoursePartnersProps) {
+    if (!partners || partners.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="mt-8">
+            <h3 className="mb-4 text-lg font-semibold text-gray-800 dark:text-gray-200">
+                Partenaires
+            </h3>
+            <div className="flex flex-wrap items-center gap-4">
+                {partners.map((partner) => (
+                    <a
+                        key={partner.id}
+                        href={partner.link ?? '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {partner.media && (
+                            <img
+                                src={partner.media.src}
+                                alt={partner.name}
+                                className="h-12 w-auto object-contain"
+                            />
+                        )}
+                    </a>
+                ))}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- show course and organization logos on course detail page
- display partner logos on course detail

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871f344c6a48333b913433297f162fe