### PR TITLE
Add search results page and fix header links

### DIFF
--- a/app/Http/Controllers/Public/PublicFormationController.php
+++ b/app/Http/Controllers/Public/PublicFormationController.php
@@ -45,6 +45,30 @@ class PublicFormationController extends PublicAbstractController
     }
 
     /**
+     * Display search results page.
+     */
+    public function searchPage(Request $request)
+    {
+        try {
+            $searchTerm = $request->input('search', '');
+            $data = $this->default_data;
+            if ($searchTerm !== '') {
+                $data['courses'] = CourseRepository::findAllBySearchText($searchTerm, 50);
+            } else {
+                $data['courses'] = [];
+            }
+
+            return Inertia::render('public/search.page', [
+                'data' => $data,
+                'searchTerm' => $searchTerm,
+            ]);
+        } catch (Exception $e) {
+            Log::error("Error in searchPage: {$e->getMessage()}");
+            return redirect()->route('home')->withErrors('Une erreur est survenue lors de la recherche.');
+        }
+    }
+
+    /**
      * Affiche la liste des formations.
      * 
      * @return \Inertia\Response

--- a/resources/js/components/layouts/header/header-search.tsx
+++ b/resources/js/components/layouts/header/header-search.tsx
@@ -2,7 +2,7 @@ import { SharedData } from '@/types';
 import { ICourse } from '@/types/course';
 import { Logger } from '@/utils/console.util';
 import { ROUTE_MAP } from '@/utils/route.util';
-import { Link, useForm, usePage } from '@inertiajs/react';
+import { Link, router, useForm, usePage } from '@inertiajs/react';
 import axios from 'axios';
 import { Loader } from 'lucide-react';
 import { useState } from 'react';
@@ -82,6 +82,13 @@ export default function HeaderSearch({ className }: HeaderSearchProps) {
         }
     };
 
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (searchText.trim() !== '') {
+            router.visit(`${ROUTE_MAP.public.search.link}?search=${encodeURIComponent(searchText)}`);
+        }
+    };
+
     // Update courseResults when search_result changes
     // useEffect(() => {
     //     if (search_result?.courses) {
@@ -93,7 +100,7 @@ export default function HeaderSearch({ className }: HeaderSearchProps) {
         <>
             <div className={className}>
                 <div className="relative mx-auto w-full max-w-xl rounded-full bg-white">
-                    <div className="flex items-center justify-center">
+                    <form className="flex items-center justify-center" onSubmit={handleSubmit}>
                         <input
                             placeholder="Rechercher des formations, des certifications, ..."
                             className="focus:border-primary-200 focus:ring-primary-200 border-[#0bbd53] h-10 w-full rounded-full border-1 bg-transparent pr-24 pl-6 outline-none hover:outline-none focus:shadow-md transition-all duration-100 ease-in-out sm:text-sm sm:font-medium"
@@ -124,7 +131,7 @@ export default function HeaderSearch({ className }: HeaderSearchProps) {
                                 ></path>
                             </svg>
                         </button>
-                    </div>
+                    </form>
                 </div>
             </div>
 
@@ -150,7 +157,7 @@ export default function HeaderSearch({ className }: HeaderSearchProps) {
                                                     courseResults.map((course) => (
                                                         <li key={course.id} className="cursor-pointer p-2 hover:bg-white dark:hover:bg-gray-700">
                                                             <Link
-                                                                classID="hover:underline"
+                                                                className="hover:underline"
                                                                 href={ROUTE_MAP.public.courses.detail(course.category?.slug ?? '', course.slug).link}
                                                             >
                                                                 {course.title}

--- a/resources/js/pages/public/search.page.tsx
+++ b/resources/js/pages/public/search.page.tsx
@@ -1,0 +1,48 @@
+import CourseTable from '@/components/courses/list/CourseTable';
+import Hero, { IHeroBreadcrumbItems } from '@/components/hero/hearo';
+import DefaultLayout from '@/layouts/public/front.layout';
+import { SharedData } from '@/types';
+import { ICourse } from '@/types/course';
+import { ROUTE_MAP } from '@/utils/route.util';
+import { usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface PageProps extends SharedData {
+    data: {
+        courses: ICourse[];
+    };
+    searchTerm: string;
+}
+
+export default function SearchPage() {
+    const { t } = useTranslation();
+    const { data, searchTerm } = usePage<PageProps>().props;
+    const [courses, setCourses] = useState<ICourse[]>([]);
+
+    const breadcrumb: IHeroBreadcrumbItems[] = [
+        { label: 'Home', href: ROUTE_MAP.public.home.link },
+        { label: t('HEADER.SEARCH_RESULTS', 'Résultats de recherche'), href: '#' },
+    ];
+
+    useEffect(() => {
+        if (data && data.courses) {
+            setCourses(data.courses);
+        }
+    }, [data]);
+
+    return (
+        <DefaultLayout title={t('HEADER.SEARCH_RESULTS', 'Résultats de recherche')}>
+            <div className="bg-gray-100 dark:bg-[#0a0e19]">
+                <Hero
+                    title={t('HEADER.SEARCH_RESULTS', 'Résultats de recherche')}
+                    description={searchTerm}
+                    breadcrumbItems={breadcrumb}
+                />
+                <div className="container mx-auto p-4">
+                    <CourseTable courses={courses} />
+                </div>
+            </div>
+        </DefaultLayout>
+    );
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -38,6 +38,7 @@ interface IROUTE_MAP {
         contact: IRouteMap;
         privacyPolicy: IRouteMap;
         termsOfService: IRouteMap;
+        search: IRouteMap;
         courses: {
             list: IRouteMap;
             byCategory: (categorySlug: string) => IRouteMap;
@@ -92,6 +93,7 @@ export const ROUTE_MAP: IROUTE_MAP = {
         contact: createIRouteMap(route('contact'), 'Nous contacter'),
         privacyPolicy: createIRouteMap(route('privacyPolicy'), 'Politique de confidentialité'),
         termsOfService: createIRouteMap(route('termsOfService'), 'Conditions d’utilisation'),
+        search: createIRouteMap(route('search.page'), 'Résultats de recherche'),
         courses: {
             list: createIRouteMap('/formations', 'Liste des formations'),
             byCategory: (categorySlug: string) => {

--- a/routes/front.php
+++ b/routes/front.php
@@ -62,6 +62,7 @@ Route::group(["prefix" => "/"], function () {
      * This route handles search queries for blogs, courses, etc.
      */
     Route::post('search', [PublicFormationController::class, 'search'])->name('search');
+    Route::get('search', [PublicFormationController::class, 'searchPage'])->name('search.page');
 
     /** 
      * formation routes


### PR DESCRIPTION
## Summary
- add GET route for search page
- implement `searchPage` controller action
- allow navigating to search results from header search box and fix Link class
- map new route in `ROUTE_MAP`
- create React page to list search results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails with module resolution errors)*
- `composer test` *(fails with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_6871f3bc77c48333b5b37c4fda46c2d5