### PR TITLE
Add enrollment management in dashboard

### DIFF
--- a/app/Http/Controllers/Private/EnrollmentController.php
+++ b/app/Http/Controllers/Private/EnrollmentController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Models\Enrollment;
+use App\Repositories\EnrollmentRepository;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+
+class EnrollmentController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->search ? strtolower($request->search) : null;
+
+        $enrollments = EnrollmentRepository::query()
+            ->when($search, function ($query) use ($search) {
+                $query->whereHas('user', function ($q) use ($search) {
+                    $q->where('name', 'like', "%{$search}%");
+                })
+                ->orWhereHas('course', function ($q) use ($search) {
+                    $q->where('title', 'like', "%{$search}%");
+                });
+            })
+            ->with(['user', 'course', 'course_session'])
+            ->withTrashed()
+            ->latest('id')
+            ->paginate(15)
+            ->withQueryString();
+
+        $currentYear = now()->year;
+        $enrollmentData = Enrollment::select(
+            DB::raw('MONTH(created_at) as month'),
+            DB::raw('COUNT(*) as count')
+        )
+            ->whereYear('created_at', $currentYear)
+            ->groupBy(DB::raw('MONTH(created_at)'))
+            ->orderBy('month')
+            ->get()
+            ->pluck('count', 'month')
+            ->toArray();
+
+        $chartData = [];
+        for ($month = 1; $month <= 12; $month++) {
+            $chartData[] = $enrollmentData[$month] ?? 0;
+        }
+
+        $chart_data = [
+            'enrollment_area' => [
+                'series' => [
+                    [
+                        'name' => 'Enrollments',
+                        'data' => $chartData,
+                    ],
+                ],
+                'categories' => [
+                    "$currentYear-01-01T00:00:00.000Z",
+                    "$currentYear-02-01T00:00:00.000Z",
+                    "$currentYear-03-01T00:00:00.000Z",
+                    "$currentYear-04-01T00:00:00.000Z",
+                    "$currentYear-05-01T00:00:00.000Z",
+                    "$currentYear-06-01T00:00:00.000Z",
+                    "$currentYear-07-01T00:00:00.000Z",
+                    "$currentYear-08-01T00:00:00.000Z",
+                    "$currentYear-09-01T00:00:00.000Z",
+                    "$currentYear-10-01T00:00:00.000Z",
+                    "$currentYear-11-01T00:00:00.000Z",
+                    "$currentYear-12-01T00:00:00.000Z",
+                ],
+            ],
+        ];
+
+        $data = [
+            'enrollments' => $enrollments,
+            'chart_data' => $chart_data,
+        ];
+
+        return Inertia::render('dashboard/enrollments/index', [
+            'data' => $data,
+        ]);
+    }
+
+    public function destroy(Enrollment $enrollment)
+    {
+        $enrollment->delete();
+        return back()->withSuccess('Enrollment deleted successfully.');
+    }
+}

--- a/resources/js/components/enrollments/EnrollmentDataTable.tsx
+++ b/resources/js/components/enrollments/EnrollmentDataTable.tsx
@@ -1,0 +1,56 @@
+import { ICourseEnrollment } from '@/types/course';
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+import { DataTable } from '../ui/dataTable';
+
+interface EnrollmentDataTableProps {
+    enrollments: ICourseEnrollment[];
+    onDeleteRow?: (row: ICourseEnrollment) => void;
+}
+
+export default function EnrollmentDataTable({ enrollments, onDeleteRow }: EnrollmentDataTableProps) {
+    const columns: ColumnDef<ICourseEnrollment>[] = [
+        {
+            accessorKey: 'user',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Utilisateur
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => <span>{row.original.user?.name || '-'}</span>,
+        },
+        {
+            accessorKey: 'course',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Formation
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => <span>{row.original.course?.title || '-'}</span>,
+        },
+        {
+            accessorKey: 'mode',
+            header: 'Mode',
+            cell: ({ row }) => <span>{row.original.mode}</span>,
+        },
+        {
+            accessorKey: 'created_at',
+            header: 'Date',
+            cell: ({ row }) => <span>{row.original.created_at?.toString().slice(0,10) || ''}</span>,
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => (
+                <Button variant="ghost" size="icon" onClick={() => onDeleteRow?.(row.original)}>
+                    <Trash2 className="text-red-600 h-4 w-4" />
+                </Button>
+            ),
+        },
+    ];
+
+    return <DataTable columns={columns} data={enrollments} filterColumn="mode" />;
+}

--- a/resources/js/components/layouts/app/side-bar-item.ts
+++ b/resources/js/components/layouts/app/side-bar-item.ts
@@ -1,5 +1,5 @@
 import { NavItem } from "@/types";
-import { BookOpen, FileStack, Folder, HomeIcon, LayoutGrid, List, ClipboardPlus, Settings2, ListTodo, BookAIcon } from 'lucide-react';
+import { BookOpen, FileStack, Folder, HomeIcon, LayoutGrid, List, ClipboardPlus, Settings2, ListTodo, BookAIcon, ListChecks } from 'lucide-react';
 
 
 export const MAIN_NAV_ITEMS: NavItem[] = [
@@ -34,6 +34,11 @@ export const MAIN_NAV_ITEMS: NavItem[] = [
                 icon: Settings2,
             },
         ],
+    },
+    {
+        title: 'Inscriptions',
+        href: route('dashboard.enrollment.index'),
+        icon: ListChecks,
     },
     {
         title: 'Partenaires',

--- a/resources/js/pages/dashboard/enrollments/index.tsx
+++ b/resources/js/pages/dashboard/enrollments/index.tsx
@@ -1,0 +1,57 @@
+import EnrollmentDataTable from '@/components/enrollments/EnrollmentDataTable';
+import EnrollmentRate from '@/components/charts/EnrollmentRate';
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { ICourseEnrollment } from '@/types/course';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Dashboard',
+        href: '/dashboard',
+    },
+    {
+        title: 'Inscriptions',
+        href: route('dashboard.enrollment.index'),
+    },
+];
+
+export default function EnrollmentDashboard() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+    const [enrollments, setEnrollments] = useState<ICourseEnrollment[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (data.enrollments?.data) {
+            setEnrollments(data.enrollments.data as unknown as ICourseEnrollment[]);
+        }
+    }, [data.enrollments]);
+
+    const handleDelete = (row: ICourseEnrollment) => {
+        setLoading(true);
+        router.delete(route('dashboard.enrollment.delete', row.id), {
+            onSuccess: () => {
+                toast.success(t('deleted', 'Supprimé'));
+                setLoading(false);
+            },
+            onError: () => {
+                toast.error(t('error', 'Erreur'));
+                setLoading(false);
+            },
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={t('Inscriptions')} />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <EnrollmentRate />
+                <EnrollmentDataTable enrollments={enrollments} onDeleteRow={handleDelete} />
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Private\SettingController;
 use App\Http\Controllers\Private\TestimonialController;
 use App\Http\Controllers\Private\ReferenceController;
 use App\Http\Controllers\Private\PartnerController;
+use App\Http\Controllers\Private\EnrollmentController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 
@@ -48,6 +49,14 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::post('store',               [CategoryController::class, 'store'])->name('dashboard.category.store');
         Route::post('update',              [CategoryController::class, 'update'])->name('dashboard.category.update');
         Route::delete('delete/{category}', [CategoryController::class, 'delete'])->name('dashboard.category.delete');
+    });
+
+    // ENROLLMENTS MANAGEMENT
+    Route::group([
+        'prefix' => 'enrollments',
+    ], function () {
+        Route::get('', [EnrollmentController::class, 'index'])->name('dashboard.enrollment.index');
+        Route::delete('delete/{enrollment}', [EnrollmentController::class, 'destroy'])->name('dashboard.enrollment.delete');
     });
 
 


### PR DESCRIPTION
## Summary
- introduce `EnrollmentController` to list and delete course enrollments
- expose enrollment management routes
- add sidebar link for enrollments
- create dashboard page with chart and table
- implement `EnrollmentDataTable` component

## Testing
- `composer install` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871fb93f3ec8333ab7b0aea4c3f2bc3