### PR TITLE
Add training calendar page

### DIFF
--- a/app/Http/Controllers/Public/PublicFormationController.php
+++ b/app/Http/Controllers/Public/PublicFormationController.php
@@ -150,4 +150,12 @@ class PublicFormationController extends PublicAbstractController
             return redirect()->route('courses')->withErrors('Une erreur est survenue lors de la récupération des données.');
         }
     }
+
+    public function calendar()
+    {
+        $data = $this->default_data;
+        return Inertia::render('public/courses/calendar.page', [
+            'data' => $data,
+        ]);
+    }
 }

--- a/app/Http/Controllers/Public/PublicFormationSessionController.php
+++ b/app/Http/Controllers/Public/PublicFormationSessionController.php
@@ -24,6 +24,17 @@ class PublicFormationSessionController extends PublicAbstractController
         $this->default_data = $this->getDefaultData();
     }
 
+    public function listSessions()
+    {
+        try {
+            $sessions = \App\Models\CourseSession::with('course')->get();
+            return response()->json(['sessions' => $sessions]);
+        } catch (Exception $e) {
+            Log::error("Error in listSessions: {$e->getMessage()}");
+            return response()->json(['error' => 'Une erreur est survenue lors de la récupération des sessions.'], 500);
+        }
+    }
+
     /**
      * Renvoie les horaires d'une session de formation.
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
                 "react-quill": "^2.0.0",
                 "react-quill-new": "^3.4.6",
                 "react-svg": "^16.3.0",
+                "react-calendar": "^4.2.1",
                 "tailwind-merge": "^3.0.1",
                 "tailwindcss": "^4.0.0",
                 "tailwindcss-animate": "^1.0.7",
@@ -7339,6 +7340,12 @@
                 "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
+        },
+        "node_modules/react-calendar": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.2.1.tgz",
+            "integrity": "",
+            "license": "MIT"
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "react-quill": "^2.0.0",
         "react-quill-new": "^3.4.6",
         "react-svg": "^16.3.0",
+        "react-calendar": "^4.2.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",

--- a/resources/js/pages/public/courses/calendar.page.tsx
+++ b/resources/js/pages/public/courses/calendar.page.tsx
@@ -1,0 +1,115 @@
+import DefaultLayout from '@/layouts/public/front.layout';
+import Hero, { IHeroBreadcrumbItems } from '@/components/hero/hearo';
+import { ROUTE_MAP } from '@/utils/route.util';
+import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import CourseInscriptionDialog from '@/components/courses/detail/partial/CourseInscriptionDialog';
+import { ICourse, ICourseSession } from '@/types/course';
+
+interface SessionWithCourse extends ICourseSession {
+    course: ICourse;
+}
+
+export default function TrainingCalendarPage() {
+    const { t } = useTranslation();
+    const [sessions, setSessions] = useState<SessionWithCourse[]>([]);
+    const [selectedSessions, setSelectedSessions] = useState<SessionWithCourse[]>([]);
+    const [selectedSession, setSelectedSession] = useState<SessionWithCourse | null>(null);
+    const [openDialog, setOpenDialog] = useState(false);
+
+    useEffect(() => {
+        axios
+            .get(route('courses.calendar.sessions'))
+            .then((res) => setSessions(res.data.sessions))
+            .catch(() => {});
+    }, []);
+
+    const onDayClick = (value: Date) => {
+        const daySessions = sessions.filter(
+            (s) => new Date(s.start_date).toDateString() === value.toDateString(),
+        );
+        setSelectedSessions(daySessions);
+    };
+
+    const tileContent = ({ date, view }: { date: Date; view: string }) => {
+        if (view === 'month') {
+            const daySessions = sessions.filter(
+                (s) => new Date(s.start_date).toDateString() === date.toDateString(),
+            );
+            if (daySessions.length > 0) {
+                return (
+                    <span className="block w-2 h-2 rounded-full bg-green-500 mx-auto mt-1" />
+                );
+            }
+        }
+        return null;
+    };
+
+    const breadcrumbItems: IHeroBreadcrumbItems[] = [
+        { label: t('PAGES.HOME', 'Accueil'), href: ROUTE_MAP.public.home.link },
+        { label: t('CALENDAR.TITLE', 'Calendrier des formations'), href: '#' },
+    ];
+
+    return (
+        <DefaultLayout
+            title={t('CALENDAR.TITLE', 'Calendrier des formations')}
+            description={t('CALENDAR.DESCRIPTION', 'Consultez nos sessions et inscrivez-vous.')}
+        >
+            <div className="bg-gray-100 dark:bg-[#0a0e19]">
+                <Hero
+                    title={t('CALENDAR.TITLE', 'Calendrier des formations')}
+                    description={t('CALENDAR.DESCRIPTION', 'Consultez nos sessions et inscrivez-vous.')}
+                    breadcrumbItems={breadcrumbItems}
+                />
+                <div className="container mx-auto my-8 p-4">
+                    <Calendar onClickDay={onDayClick} tileContent={tileContent} />
+                    <div className="mt-6 space-y-4">
+                        {selectedSessions.map((session) => (
+                            <div
+                                key={session.id}
+                                className="border rounded-md p-4 flex flex-col md:flex-row justify-between items-start md:items-center"
+                            >
+                                <div>
+                                    <h3 className="font-semibold text-lg text-black dark:text-white">
+                                        {session.course?.title}
+                                    </h3>
+                                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                                        {session.start_date} - {session.end_date} - {session.location}
+                                    </p>
+                                </div>
+                                <div className="flex gap-2 mt-2 md:mt-0">
+                                    <button
+                                        className="bg-green-500 hover:bg-green-600 text-white rounded-md px-4 py-2 text-sm"
+                                        onClick={() => {
+                                            setSelectedSession(session);
+                                            setOpenDialog(true);
+                                        }}
+                                    >
+                                        {t('COURSE.DETAIL.REGISTER', 'Inscription')}
+                                    </button>
+                                    <a
+                                        href={`${ROUTE_MAP.public.contact.link}?subject=Formation ${session.course?.title}`}
+                                        className="bg-blue-500 hover:bg-blue-600 text-white rounded-md px-4 py-2 text-sm"
+                                    >
+                                        {t('CALENDAR.CONTACT_US', 'Demander une autre date')}
+                                    </a>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+            {selectedSession && (
+                <CourseInscriptionDialog
+                    course={selectedSession.course}
+                    session={selectedSession}
+                    isOpen={openDialog}
+                    onOpenChange={setOpenDialog}
+                />
+            )}
+        </DefaultLayout>
+    );
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -39,6 +39,7 @@ interface IROUTE_MAP {
         privacyPolicy: IRouteMap;
         termsOfService: IRouteMap;
         search: IRouteMap;
+        calendar: IRouteMap;
         courses: {
             list: IRouteMap;
             byCategory: (categorySlug: string) => IRouteMap;
@@ -94,6 +95,7 @@ export const ROUTE_MAP: IROUTE_MAP = {
         privacyPolicy: createIRouteMap(route('privacyPolicy'), 'Politique de confidentialité'),
         termsOfService: createIRouteMap(route('termsOfService'), 'Conditions d’utilisation'),
         search: createIRouteMap(route('search.page'), 'Résultats de recherche'),
+        calendar: createIRouteMap(route('courses.calendar'), 'Calendrier des formations'),
         courses: {
             list: createIRouteMap('/formations', 'Liste des formations'),
             byCategory: (categorySlug: string) => {

--- a/resources/locales/en.json
+++ b/resources/locales/en.json
@@ -49,6 +49,11 @@
         "emailPlaceholder": "email@example.com",
         "submit": "Email password reset link",
         "orReturn": "Or, return to",
-        "login": "log in"
-    }
+  "login": "log in"
+  },
+  "CALENDAR": {
+    "TITLE": "Training calendar",
+    "DESCRIPTION": "Check our upcoming sessions and register.",
+    "CONTACT_US": "Request another date"
+  }
 }

--- a/resources/locales/fr.json
+++ b/resources/locales/fr.json
@@ -50,5 +50,10 @@
         "submit": "Envoyer le lien de réinitialisation",
         "orReturn": "Ou, retour à",
         "login": "connexion"
+    },
+    "CALENDAR": {
+        "TITLE": "Calendrier des formations",
+        "DESCRIPTION": "Consultez nos prochaines sessions et inscrivez-vous.",
+        "CONTACT_US": "Demander une autre date"
     }
 }

--- a/routes/front.php
+++ b/routes/front.php
@@ -64,6 +64,9 @@ Route::group(["prefix" => "/"], function () {
     Route::post('search', [PublicFormationController::class, 'search'])->name('search');
     Route::get('search', [PublicFormationController::class, 'searchPage'])->name('search.page');
 
+    Route::get('formations-calendar', [PublicFormationController::class, 'calendar'])->name('courses.calendar');
+    Route::get('formations-calendar/sessions', [PublicFormationSessionController::class, 'listSessions'])->name('courses.calendar.sessions');
+
     /** 
      * formation routes
      * These routes handle course listings, categories, and details.


### PR DESCRIPTION
## Summary
- add calendar page for training sessions
- expose sessions list route and page controller
- register calendar URLs
- support calendar route in frontend utils
- add localization strings for calendar
- include `react-calendar` dependency

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: Cannot find module 'framer-motion')*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871febdf3a883338f0ac8d91bd6c320