### PR TITLE
Add admin notification for user registration

### DIFF
--- a/app/Enum/NotificationTypeEnum.php
+++ b/app/Enum/NotificationTypeEnum.php
@@ -10,4 +10,5 @@ enum NotificationTypeEnum: string
     case NewQuizFromCourse          = 'new_quiz_from_course';
     case CustomNotification         = 'new_custom_notification_from_admin';
     case NewEnrollmentNotification  = 'new_enrollment_notification';
+    case NewUserRegistered          = 'new_user_registered';
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -12,6 +12,7 @@ use App\Repositories\FcmDeviceTokenRepository;
 use App\Repositories\GuestRepository;
 use App\Repositories\UserRepository;
 use App\Services\ResponseService;
+use App\Services\Notification\UserRegistrationNotificationService;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -79,6 +80,9 @@ class RegisteredUserController extends Controller
             }
 
             $newUser->refresh();
+
+            // Notify admin about new user registration
+            UserRegistrationNotificationService::notifyUserRegistered($newUser);
 
             // return ResponseService::created('Registration successful', [
             //     'user'            => UserResource::make($newUser),

--- a/app/Http/Controllers/Private/NotificationController.php
+++ b/app/Http/Controllers/Private/NotificationController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\NotificationInstanceResource;
+use App\Repositories\NotificationInstanceRepository;
+use Illuminate\Http\Request;
+
+class NotificationController extends PrivateAbstractController
+{
+    public function index(Request $request)
+    {
+        $notifications = NotificationInstanceRepository::query()
+            ->where(function ($query) {
+                $userId = auth()->id();
+                $query->whereNull('recipient_id');
+                if ($userId) {
+                    $query->orWhere('recipient_id', $userId);
+                }
+            })
+            ->latest()
+            ->limit(10)
+            ->get();
+
+        return response()->json([
+            'notifications' => NotificationInstanceResource::collection($notifications),
+        ]);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -12,6 +12,7 @@ use App\Repositories\FcmDeviceTokenRepository;
 use App\Repositories\GuestRepository;
 use App\Repositories\UserRepository;
 use App\Services\ResponseService;
+use App\Services\Notification\UserRegistrationNotificationService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
@@ -57,6 +58,9 @@ class UserController extends Controller
         }
 
         $newUser->refresh();
+
+        // Notify admin about new user registration
+        UserRegistrationNotificationService::notifyUserRegistered($newUser);
 
         return ResponseService::created('Registration successful', [
             'user'            => UserResource::make($newUser),

--- a/app/Services/Notification/UserRegistrationNotificationService.php
+++ b/app/Services/Notification/UserRegistrationNotificationService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\Notification;
+
+use App\Enum\NotificationTypeEnum;
+use App\Models\User;
+use App\Repositories\NotificationInstanceRepository;
+use App\Repositories\NotificationRepository;
+
+class UserRegistrationNotificationService
+{
+    public static function notifyUserRegistered(User $user)
+    {
+        try {
+            $notification = NotificationRepository::query()
+                ->where('type', NotificationTypeEnum::NewUserRegistered->value)
+                ->first();
+
+            if (!$notification) {
+                return;
+            }
+
+            $contentText = str_replace('{user_name}', $user->name, $notification->content);
+
+            NotificationInstanceRepository::create([
+                'notification_id' => $notification->id,
+                'recipient_id'    => null,
+                'course_id'       => null,
+                'metadata'        => json_encode($user),
+                'content'         => $contentText,
+            ]);
+        } catch (\Exception $e) {
+            // Fail silently
+        }
+    }
+}

--- a/database/seeders/NotificationSeeder.php
+++ b/database/seeders/NotificationSeeder.php
@@ -56,5 +56,13 @@ class NotificationSeeder extends Seeder
             'heading' => 'Nouvelle inscription au cours',
             'content' => 'Félicitations ! Vous êtes maintenant inscrit à {course_title}. Débloquons ensemble de nouvelles opportunités !',
         ]);
+
+        NotificationRepository::query()->updateOrCreate([
+            'type' => NotificationTypeEnum::NewUserRegistered->value,
+        ], [
+            'is_enabled' => true,
+            'heading' => 'Nouvelle inscription utilisateur',
+            'content' => 'L\'utilisateur {user_name} vient de s\'inscrire sur la plateforme',
+        ]);
     }
 }

--- a/resources/js/components/notification/NotificationsDropdown.tsx
+++ b/resources/js/components/notification/NotificationsDropdown.tsx
@@ -7,31 +7,30 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import axios from 'axios';
 import { Bell } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import type { INotificationInstance } from '@/types';
 import { Button } from '../ui/button/button';
 
-const notifications = [
-    {
-        id: 1,
-        title: 'Nouveau message',
-        description: 'Vous avez reçu un message de John Doe',
-        time: 'Il y a 5 minutes',
-    },
-    {
-        id: 2,
-        title: 'Mise à jour système',
-        description: 'Une nouvelle version est disponible',
-        time: 'Il y a 1 heure',
-    },
-    {
-        id: 3,
-        title: 'Rappel réunion',
-        description: "Réunion d'équipe à 14h",
-        time: 'Il y a 2 heures',
-    },
-];
-
 export function NotificationsDropdown() {
+    const [notifications, setNotifications] = useState<INotificationInstance[]>([]);
+
+    const fetchNotifications = () => {
+        axios
+            .get(route('dashboard.notifications.index'))
+            .then((res) => {
+                setNotifications(res.data.notifications ?? []);
+            })
+            .catch(() => {
+                setNotifications([]);
+            });
+    };
+
+    useEffect(() => {
+        fetchNotifications();
+    }, []);
+
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -54,17 +53,11 @@ export function NotificationsDropdown() {
                 ) : (
                     notifications.map((notification) => (
                         <DropdownMenuItem key={notification.id} className="flex-col items-start gap-1">
-                            <div className="text-sm font-medium">{notification.title}</div>
-                            <div className="text-sm text-muted-foreground">{notification.description}</div>
-                            <div className="text-xs text-muted-foreground">{notification.time}</div>
+                            <div className="text-sm font-medium">{notification.heading}</div>
+                            <div className="text-sm text-muted-foreground">{notification.content}</div>
+                            <div className="text-xs text-muted-foreground">{notification.created_at}</div>
                         </DropdownMenuItem>
                     ))
-                )}
-                {notifications.length > 0 && (
-                    <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem className="text-center justify-center">Voir toutes les notifications</DropdownMenuItem>
-                    </>
                 )}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -70,3 +70,4 @@ export interface IDataWithPagination<T> {
 
 export * from './reference';
 export * from './partner';
+export * from './notification';

--- a/resources/js/types/notification.d.ts
+++ b/resources/js/types/notification.d.ts
@@ -1,0 +1,11 @@
+export interface INotificationInstance {
+    id: number;
+    course_id: number | null;
+    heading: string;
+    title: string | null;
+    content: string;
+    is_read: boolean;
+    created_at: string;
+    date_format: string;
+    raw_time: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Private\TestimonialController;
 use App\Http\Controllers\Private\ReferenceController;
 use App\Http\Controllers\Private\PartnerController;
 use App\Http\Controllers\Private\EnrollmentController;
+use App\Http\Controllers\Private\NotificationController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 
@@ -25,6 +26,9 @@ use Inertia\Inertia;
 Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () {
     // DASHBOARD HOME
     Route::get('', [DashboardController::class, 'index'])->name('dashboard.index');
+
+    // NOTIFICATIONS
+    Route::get('notifications', [NotificationController::class, 'index'])->name('dashboard.notifications.index');
 
 
     // COURSE MANAGEMENT


### PR DESCRIPTION
## Summary
- notify admin when a user registers
- seed default admin notification text
- expose notification fetch endpoint
- show notifications dropdown items
- add TS types for notifications

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: requires ext-sodium)*
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68721c7fc19c8333a25548cfdef59229