### PR TITLE
Add newsletter management

### DIFF
--- a/app/Http/Controllers/Private/NewsletterController.php
+++ b/app/Http/Controllers/Private/NewsletterController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\NewsletterStoreRequest;
+use App\Models\Newsletter;
+use App\Repositories\NewsletterRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class NewsletterController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->search ? strtolower($request->search) : null;
+
+        $newsletters = NewsletterRepository::query()
+            ->when($search, fn($query) => $query->where('email', 'like', "%{$search}%"))
+            ->latest('id')
+            ->paginate(15)
+            ->withQueryString();
+
+        $data = [
+            'newsletters' => $newsletters,
+        ];
+
+        return Inertia::render('dashboard/newsletters/index', [
+            'data' => $data,
+        ]);
+    }
+
+    public function store(NewsletterStoreRequest $request)
+    {
+        NewsletterRepository::storeByRequest($request);
+
+        return to_route('dashboard.newsletters.index')->withSuccess('Newsletter created successfully.');
+    }
+
+    public function destroy(Newsletter $newsletter)
+    {
+        $newsletter->delete();
+        return to_route('dashboard.newsletters.index')->withSuccess('Newsletter deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Public/NewsletterController.php
+++ b/app/Http/Controllers/Public/NewsletterController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\NewsletterStoreRequest;
+use App\Repositories\NewsletterRepository;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+class NewsletterController extends Controller
+{
+    public function subscribe(NewsletterStoreRequest $request)
+    {
+        try {
+            $newsletter = NewsletterRepository::storeByRequest($request);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Subscription saved successfully.',
+                'data' => [
+                    'newsletter' => $newsletter,
+                ],
+            ]);
+        } catch (Exception $e) {
+            Log::error('Newsletter subscribe error: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Failed to subscribe to newsletter.',
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Requests/NewsletterStoreRequest.php
+++ b/app/Http/Requests/NewsletterStoreRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NewsletterStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email|unique:newsletters,email',
+        ];
+    }
+}

--- a/app/Models/Newsletter.php
+++ b/app/Models/Newsletter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Newsletter extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'email',
+    ];
+}

--- a/app/Repositories/NewsletterRepository.php
+++ b/app/Repositories/NewsletterRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\Newsletter;
+
+class NewsletterRepository extends Repository
+{
+    public static function model()
+    {
+        return Newsletter::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'email' => $request->email,
+        ]);
+    }
+}

--- a/database/migrations/2025_07_12_044500_create_newsletters_table.php
+++ b/database/migrations/2025_07_12_044500_create_newsletters_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('newsletters', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('newsletters');
+    }
+};

--- a/resources/js/components/layouts/app/side-bar-item.ts
+++ b/resources/js/components/layouts/app/side-bar-item.ts
@@ -1,5 +1,5 @@
 import { NavItem } from "@/types";
-import { BookOpen, FileStack, Folder, HomeIcon, LayoutGrid, List, ClipboardPlus, Settings2, ListTodo, BookAIcon, ListChecks } from 'lucide-react';
+import { BookOpen, FileStack, Folder, HomeIcon, LayoutGrid, List, ClipboardPlus, Settings2, ListTodo, BookAIcon, ListChecks, Mail } from 'lucide-react';
 
 
 export const MAIN_NAV_ITEMS: NavItem[] = [
@@ -64,6 +64,11 @@ export const MAIN_NAV_ITEMS: NavItem[] = [
         title: 'Faqs',
         href: route('dashboard.faqs.index'),
         icon: BookOpen,
+    },
+    {
+        title: 'Newsletters',
+        href: route('dashboard.newsletters.index'),
+        icon: Mail,
     },
     {
         title: 'Paramètres',

--- a/resources/js/components/newsletter/newletter-cta.tsx
+++ b/resources/js/components/newsletter/newletter-cta.tsx
@@ -1,8 +1,24 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import BtnSecondary from '../ui/button/btn-secondary';
+import axios from 'axios';
+import toast from 'react-hot-toast';
 
 export default function NewsletterCTA() {
     const { t } = useTranslation();
+    const [email, setEmail] = useState('');
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (email === '') return;
+        axios
+            .post(route('newsletter.subscribe'), { email })
+            .then(() => {
+                toast.success(t('newsletter.subscribed', 'Inscription réussie'));
+                setEmail('');
+            })
+            .catch(() => toast.error(t('newsletter.error', 'Erreur lors de l\'inscription')));
+    };
 
     return (
         <section className="body-font text-gray-600 dark:bg-[#0a0e19] dark:text-white">
@@ -63,7 +79,7 @@ export default function NewsletterCTA() {
                         <p className="lg:text-md text-white md:text-[15px] animate-fade-in-up animation-delay-200">
                             {t('NEWSLETTER.CTA.DESCRIPTION', 'Rejoignez notre communauté de professionnels de l’assistance.')}
                         </p>
-                        <form action="#" className="relative mx-auto mt-[20px] md:mt-[35px] md:max-w-[496px] lg:mt-[45px]">
+                        <form onSubmit={handleSubmit} className="relative mx-auto mt-[20px] md:mt-[35px] md:max-w-[496px] lg:mt-[45px]">
                             <div className="flex item-cente justify-betweenr">
                                 <span className="material-symbols-outlined absolute top-[14px] !text-[22px] text-gray-400 md:top-[21px] md:!text-[26px] ltr:left-[20px] ltr:md:left-[30px] rtl:right-[20px] rtl:md:right-[30px] animate-pulse">
                                     <svg
@@ -82,7 +98,9 @@ export default function NewsletterCTA() {
                                     </svg>
                                 </span>
                                 <input
-                                    type="text"
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
                                     className="fw-medium block w-2/3 rounded-[100px] bg-gray-800 text-base text-white !outline-0 placeholder:text-gray-300 transition-all duration-300 focus:ring-2 focus:ring-blue-500 focus:scale-105 py-2 px-4"
                                     placeholder="Entrez votre adresse e-mail"
                                 />

--- a/resources/js/components/newsletter/newsletterDataTable.tsx
+++ b/resources/js/components/newsletter/newsletterDataTable.tsx
@@ -1,0 +1,40 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, Trash2 } from 'lucide-react';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import { INewsletter } from '@/types/newsletter';
+
+interface NewsletterDataTableProps {
+    newsletters: INewsletter[];
+    onDeleteRow?: (row: INewsletter) => void;
+}
+
+export default function NewsletterDataTable({ newsletters, onDeleteRow }: NewsletterDataTableProps) {
+    const columns: ColumnDef<INewsletter>[] = [
+        {
+            accessorKey: 'email',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Email
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
+            accessorKey: 'created_at',
+            header: 'Date',
+            cell: ({ row }) => <span>{row.original.created_at?.toString().slice(0, 10) || ''}</span>,
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => (
+                <Button variant="ghost" size="icon" onClick={() => onDeleteRow?.(row.original)}>
+                    <Trash2 className="text-red-600 h-4 w-4" />
+                </Button>
+            ),
+        },
+    ];
+
+    return <DataTable columns={columns} data={newsletters} filterColumn="email" />;
+}

--- a/resources/js/components/newsletter/newsletterForm.tsx
+++ b/resources/js/components/newsletter/newsletterForm.tsx
@@ -1,0 +1,48 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { INewsletter } from '@/types/newsletter';
+
+interface NewsletterFormProps {
+    closeDrawer?: () => void;
+}
+
+const defaultValues: INewsletter = {
+    email: '',
+};
+
+export default function NewsletterForm({ closeDrawer }: NewsletterFormProps) {
+    const { t } = useTranslation();
+    const { data, setData, processing, errors, reset } = useForm<INewsletter>(defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        router.post(route('dashboard.newsletters.store'), {
+            email: data.email,
+        }, {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success(t('newsletter.created', 'Newsletter ajoutée'));
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Input id="email" required value={data.email} onChange={(e) => setData('email', e.target.value)} disabled={processing} placeholder="Email" />
+                <InputError message={errors.email} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/newsletter/newsletterToolBar.tsx
+++ b/resources/js/components/newsletter/newsletterToolBar.tsx
@@ -1,0 +1,32 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface INewsletterToolBarProps {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function NewsletterToolBar({ FormComponent, open, setOpen }: INewsletterToolBarProps) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('Newsletters')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add newsletter', 'Ajouter')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && <Drawer title={t('Newsletters.add', 'Ajouter')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/newsletters/index.tsx
+++ b/resources/js/pages/dashboard/newsletters/index.tsx
@@ -1,0 +1,88 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import NewsletterForm from '@/components/newsletter/newsletterForm';
+import NewsletterToolBar from '@/components/newsletter/newsletterToolBar';
+import NewsletterDataTable from '@/components/newsletter/newsletterDataTable';
+import { INewsletter } from '@/types/newsletter';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Newsletters',
+        href: '/dashboard/newsletters',
+    },
+    {
+        title: 'Dashboard',
+        href: route('dashboard.index'),
+    },
+];
+
+export default function DashboardNewsletters() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+
+    const [newsletters, setNewsletters] = useState<INewsletter[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<INewsletter | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && (data.newsletters as any)?.data) {
+            setNewsletters((data.newsletters as any).data);
+        } else if (data && Array.isArray(data.newsletters)) {
+            setNewsletters(data.newsletters as any);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.newsletters.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('newsletter.deleted', 'Newsletter supprimée'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Dashboard" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <NewsletterToolBar
+                    FormComponent={<NewsletterForm closeDrawer={() => setOpenForm(false)} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete newsletter', 'Supprimer la newsletter')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {newsletters && (
+                        <NewsletterDataTable
+                            newsletters={newsletters}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/newsletter.d.ts
+++ b/resources/js/types/newsletter.d.ts
@@ -1,0 +1,6 @@
+export interface INewsletter {
+    id?: number;
+    email: string;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -147,5 +147,8 @@ export const ROUTE_MAP: IROUTE_MAP = {
                 return createIRouteMap(route('dashboard.blogs.edit', { slug }), 'Modifier le blog');
             },
         },
+        newsletters: {
+            index: createIRouteMap(route('dashboard.newsletters.index'), 'Newsletters'),
+        },
     }
 }

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -151,4 +151,13 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::delete('delete/{partner}', [PartnerController::class, 'destroy'])->name('dashboard.partners.delete');
         Route::post('restore/{partner}', [PartnerController::class, 'restore'])->name('dashboard.partners.restore');
     });
+
+    // NEWSLETTERS
+    Route::group([
+        'prefix' => 'newsletters',
+    ], function () {
+        Route::get('', [\App\Http\Controllers\Private\NewsletterController::class, 'index'])->name('dashboard.newsletters.index');
+        Route::post('create', [\App\Http\Controllers\Private\NewsletterController::class, 'store'])->name('dashboard.newsletters.store');
+        Route::delete('delete/{newsletter}', [\App\Http\Controllers\Private\NewsletterController::class, 'destroy'])->name('dashboard.newsletters.delete');
+    });
 });

--- a/routes/front.php
+++ b/routes/front.php
@@ -29,6 +29,8 @@ Route::group(["prefix" => "/"], function () {
     Route::get('contact', [ContactUsController::class, 'contact'])->name('contact');
     Route::post('contact', [ContactUsController::class, 'contactSubmit'])->name('contact.post');
 
+    Route::post('newsletter', [\App\Http\Controllers\Public\NewsletterController::class, 'subscribe'])->name('newsletter.subscribe');
+
     /**
      * Consulting routes
      */


### PR DESCRIPTION
## Summary
- allow newsletter subscription from the public site
- manage newsletter subscribers in the dashboard
- include newsletter link in navigation
- define newsletter routes and utilities
- add migration and model

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687221aca52c8333bbcf952b6c644825