### PR TITLE
Fix filters on courses page

### DIFF
--- a/resources/js/components/courses/list/SidebarFilter.tsx
+++ b/resources/js/components/courses/list/SidebarFilter.tsx
@@ -27,29 +27,37 @@ export default function SidebarFilter({ courses, onFilterChange }: SidebarFilter
     }, [courses]);
 
     // Appliquer les filtres
-    // useEffect(() => {
-    //     let filteredCourses = [...courses];
+    useEffect(() => {
+        let filteredCourses = [...courses];
 
-    //     // Filtre par titre
-    //     if (title) {
-    //         filteredCourses = filteredCourses.filter((course) => course.title.toLowerCase().includes(title.toLowerCase()));
-    //     }
+        // Filtre par titre
+        if (title) {
+            filteredCourses = filteredCourses.filter((course) =>
+                course.title.toLowerCase().includes(title.toLowerCase()),
+            );
+        }
 
-    //     // Filtre par prix
-    //     filteredCourses = filteredCourses.filter((course) => course.price >= priceRange[0] && course.price <= priceRange[1]);
+        // Filtre par prix
+        filteredCourses = filteredCourses.filter(
+            (course) => course.price >= priceRange[0] && course.price <= priceRange[1],
+        );
 
-    //     // Filtre par catégorie
-    //     if (selectedCategory) {
-    //         filteredCourses = filteredCourses.filter((course) => course.categories?.some((category) => category.id === Number(selectedCategory)));
-    //     }
+        // Filtre par catégorie
+        if (selectedCategory) {
+            filteredCourses = filteredCourses.filter((course) =>
+                course.categories?.some((category) => category.id === Number(selectedCategory)),
+            );
+        }
 
-    //     // Filtre par prochaine session
-    //     if (nextSession) {
-    //         filteredCourses = filteredCourses.filter((course) => course.nextSession && course.nextSession.includes(nextSession));
-    //     }
+        // Filtre par prochaine session
+        if (nextSession) {
+            filteredCourses = filteredCourses.filter(
+                (course) => course.nextSession && course.nextSession.includes(nextSession),
+            );
+        }
 
-    //     onFilterChange(filteredCourses);
-    // }, [title, priceRange, selectedCategory, nextSession, courses, onFilterChange]);
+        onFilterChange(filteredCourses);
+    }, [title, priceRange, selectedCategory, nextSession, courses, onFilterChange]);
 
     // Gestion des changements de la plage de prix
     const handlePriceChange = (index: number, value: string) => {


### PR DESCRIPTION
## Summary
- enable filters in `SidebarFilter` so that course search by title, price, category and session works

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6872220d6fa88333b1787fa36378ef11