### PR TITLE
Add job offer CRUD and application form

### DIFF
--- a/app/Http/Controllers/Private/JobOfferController.php
+++ b/app/Http/Controllers/Private/JobOfferController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\JobOfferStoreRequest;
+use App\Http\Requests\JobOfferUpdateRequest;
+use App\Models\JobOffer;
+use App\Repositories\JobOfferRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class JobOfferController extends Controller
+{
+    public function index(Request $request)
+    {
+        $offers = JobOfferRepository::query()->withTrashed()->latest('id')->get();
+        $data = [
+            'offers' => $offers,
+        ];
+        return Inertia::render('dashboard/job-offers/index', [
+            'data' => $data,
+        ]);
+    }
+
+    public function store(JobOfferStoreRequest $request)
+    {
+        JobOfferRepository::storeByRequest($request);
+        return redirect()->back()->withSuccess('Offer created');
+    }
+
+    public function update(JobOfferUpdateRequest $request, JobOffer $jobOffer)
+    {
+        JobOfferRepository::updateByRequest($request, $jobOffer);
+        return redirect()->back()->withSuccess('Offer updated');
+    }
+
+    public function destroy(JobOffer $jobOffer)
+    {
+        $jobOffer->delete();
+        $jobOffer->is_active = false;
+        $jobOffer->save();
+        return redirect()->back()->withSuccess('Offer deleted');
+    }
+
+    public function restore($id)
+    {
+        JobOfferRepository::query()->withTrashed()->find($id)->restore();
+        return redirect()->back()->withSuccess('Offer restored');
+    }
+
+    public function toggle(JobOffer $jobOffer)
+    {
+        $jobOffer->is_active = !$jobOffer->is_active;
+        $jobOffer->save();
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/Public/PublicJobController.php
+++ b/app/Http/Controllers/Public/PublicJobController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\JobApplicationStoreRequest;
+use App\Models\JobOffer;
+use App\Repositories\JobApplicationRepository;
+use App\Repositories\JobOfferRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class PublicJobController extends Controller
+{
+    public function list()
+    {
+        $offers = JobOfferRepository::query()->where('is_active', true)->latest('id')->get();
+        $data['job_offers'] = $offers;
+        return Inertia::render('public/careers/careers', [
+            'data' => $data,
+        ]);
+    }
+
+    public function apply(JobApplicationStoreRequest $request)
+    {
+        JobApplicationRepository::storeByRequest($request);
+        return redirect()->back()->withSuccess('Application sent');
+    }
+}

--- a/app/Http/Requests/JobApplicationStoreRequest.php
+++ b/app/Http/Requests/JobApplicationStoreRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobApplicationStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'job_offer_id' => 'required|exists:job_offers,id',
+            'name' => 'required|string',
+            'email' => 'required|email',
+            'message' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/JobOfferStoreRequest.php
+++ b/app/Http/Requests/JobOfferStoreRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobOfferStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string',
+            'company' => 'nullable|string',
+            'location' => 'nullable|string',
+            'type' => 'nullable|string',
+            'salary' => 'nullable|integer',
+            'description' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/JobOfferUpdateRequest.php
+++ b/app/Http/Requests/JobOfferUpdateRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobOfferUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string',
+            'company' => 'nullable|string',
+            'location' => 'nullable|string',
+            'type' => 'nullable|string',
+            'salary' => 'nullable|integer',
+            'description' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Models/JobApplication.php
+++ b/app/Models/JobApplication.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JobApplication extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+}

--- a/app/Models/JobOffer.php
+++ b/app/Models/JobOffer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class JobOffer extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $guarded = ['id'];
+}

--- a/app/Repositories/JobApplicationRepository.php
+++ b/app/Repositories/JobApplicationRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\JobApplication;
+
+class JobApplicationRepository extends Repository
+{
+    public static function model()
+    {
+        return JobApplication::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'job_offer_id' => $request->job_offer_id,
+            'name' => $request->name,
+            'email' => $request->email,
+            'message' => $request->message,
+        ]);
+    }
+}

--- a/app/Repositories/JobOfferRepository.php
+++ b/app/Repositories/JobOfferRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\JobOffer;
+
+class JobOfferRepository extends Repository
+{
+    public static function model()
+    {
+        return JobOffer::class;
+    }
+
+    public static function storeByRequest($request)
+    {
+        return self::create([
+            'title' => $request->title,
+            'company' => $request->company,
+            'location' => $request->location,
+            'type' => $request->type,
+            'salary' => $request->salary,
+            'description' => $request->description,
+            'is_active' => $request->has('is_active') ? true : false,
+        ]);
+    }
+
+    public static function updateByRequest($request, JobOffer $offer)
+    {
+        return self::update($offer, [
+            'title' => $request->title ?? $offer->title,
+            'company' => $request->company ?? $offer->company,
+            'location' => $request->location ?? $offer->location,
+            'type' => $request->type ?? $offer->type,
+            'salary' => $request->salary ?? $offer->salary,
+            'description' => $request->description ?? $offer->description,
+            'is_active' => $request->has('is_active') ? true : $offer->is_active,
+        ]);
+    }
+}

--- a/database/migrations/2025_07_12_050000_create_job_offers_table.php
+++ b/database/migrations/2025_07_12_050000_create_job_offers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('job_offers', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('company')->nullable();
+            $table->string('location')->nullable();
+            $table->string('type')->nullable();
+            $table->integer('salary')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('job_offers');
+    }
+};

--- a/database/migrations/2025_07_12_050500_create_job_applications_table.php
+++ b/database/migrations/2025_07_12_050500_create_job_applications_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('job_applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('job_offer_id')->constrained('job_offers')->onDelete('cascade');
+            $table->string('name');
+            $table->string('email');
+            $table->text('message')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('job_applications');
+    }
+};

--- a/resources/js/components/careers/JobApplyModal.tsx
+++ b/resources/js/components/careers/JobApplyModal.tsx
@@ -1,0 +1,65 @@
+import { IJobApplication } from '@/types';
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+
+interface Props {
+    jobId: number;
+    open: boolean;
+    onClose: () => void;
+}
+
+export default function JobApplyModal({ jobId, open, onClose }: Props) {
+    const [form, setForm] = useState<IJobApplication>({
+        job_offer_id: jobId,
+        name: '',
+        email: '',
+        message: '',
+    });
+
+    if (!open) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    router.post(route('job.apply'), form, {
+                        onSuccess: onClose,
+                    });
+                }}
+                className="space-y-4 rounded bg-white p-6"
+            >
+                <h2 className="text-xl font-bold">Postuler</h2>
+                <input
+                    className="w-full rounded border p-2"
+                    placeholder="Nom"
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                    required
+                />
+                <input
+                    className="w-full rounded border p-2"
+                    placeholder="Email"
+                    type="email"
+                    value={form.email}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    required
+                />
+                <textarea
+                    className="w-full rounded border p-2"
+                    placeholder="Message"
+                    value={form.message}
+                    onChange={(e) => setForm({ ...form, message: e.target.value })}
+                />
+                <div className="flex justify-end gap-2">
+                    <button type="button" onClick={onClose} className="rounded bg-gray-200 px-4 py-2">
+                        Annuler
+                    </button>
+                    <button type="submit" className="rounded bg-primary-600 px-4 py-2 text-white">
+                        Envoyer
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/resources/js/components/careers/JobCard.tsx
+++ b/resources/js/components/careers/JobCard.tsx
@@ -1,15 +1,17 @@
-import { JobOffer } from '@/pages/public/careers/careers';
-import { Link } from '@inertiajs/react';
+import { IJobOffer } from '@/types';
 import { motion, Variants } from 'framer-motion';
-import React from 'react';
+import React, { useState } from 'react';
+import JobApplyModal from './JobApplyModal';
 
 // Composant pour une carte d'offre d'emploi
-export const JobCard: React.FC<{ job: JobOffer }> = ({ job }) => {
+export const JobCard: React.FC<{ job: IJobOffer }> = ({ job }) => {
     const cardVariants: Variants = {
         hidden: { opacity: 0, scale: 0.95 },
         visible: { opacity: 1, scale: 1, transition: { duration: 0.4, ease: 'easeOut' } },
         hover: { y: -5, boxShadow: '0 8px 16px rgba(0, 0, 0, 0.1)', transition: { duration: 0.3 } },
     };
+
+    const [open, setOpen] = useState(false);
 
     return (
         <motion.div
@@ -27,13 +29,14 @@ export const JobCard: React.FC<{ job: JobOffer }> = ({ job }) => {
                 {job.type} - {job.salary.toLocaleString()} €/an
             </p>
             <p className="text-gray-600 dark:text-gray-300 mt-2 line-clamp-2">{job.description}</p>
-            <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">Publié le {job.postedAt}</p>
-            <Link
-                href={`/jobs/${job.id}`}
+            <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">Publié le {job.created_at}</p>
+            <button
+                onClick={() => setOpen(true)}
                 className="mt-4 inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600"
             >
-                Voir les détails
-            </Link>
+                Postuler
+            </button>
+            <JobApplyModal jobId={job.id!} open={open} onClose={() => setOpen(false)} />
         </motion.div>
     );
 };

--- a/resources/js/components/careers/JobList.tsx
+++ b/resources/js/components/careers/JobList.tsx
@@ -1,7 +1,7 @@
-import { JobOffer } from '@/pages/public/careers/careers';
+import { IJobOffer } from '@/types';
 import { JobCard } from './JobCard';
 
-export const JobList: React.FC<{ jobs: JobOffer[] }> = ({ jobs }) => {
+export const JobList: React.FC<{ jobs: IJobOffer[] }> = ({ jobs }) => {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {jobs.length > 0 ? (

--- a/resources/js/components/job-offers/jobOfferActionBtn.tsx
+++ b/resources/js/components/job-offers/jobOfferActionBtn.tsx
@@ -1,0 +1,28 @@
+import { IJobOffer } from '@/types';
+import { SquarePen, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button/button';
+
+interface Props {
+    row: { original: IJobOffer };
+    onEdit?: (row: IJobOffer) => void;
+    onDelete?: (row: IJobOffer) => void;
+    onToggle?: (row: IJobOffer) => void;
+}
+
+export default function JobOfferActionBtn({ row, onEdit, onDelete, onToggle }: Props) {
+    return (
+        <div className="flex space-x-2">
+            <Button variant={'ghost'} size="icon" onClick={() => onEdit?.(row.original)}>
+                <SquarePen className="h-4 w-4" />
+                <span className="sr-only">Modifier</span>
+            </Button>
+            <Button variant={'ghost'} size="icon" onClick={() => onToggle?.(row.original)}>
+                <span className="sr-only">Activer/desactiver</span>
+            </Button>
+            <Button variant={'ghost'} size="icon" onClick={() => onDelete?.(row.original)}>
+                <Trash2 className="text-red h-4 w-4" style={{ color: 'red' }} />
+                <span className="sr-only">Supprimer</span>
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/components/job-offers/jobOfferDataTable.tsx
+++ b/resources/js/components/job-offers/jobOfferDataTable.tsx
@@ -1,0 +1,55 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import JobOfferActionBtn from './jobOfferActionBtn';
+import { IJobOffer } from '@/types';
+
+interface Props {
+    offers: IJobOffer[];
+    onEditRow?: (row: IJobOffer) => void;
+    onDeleteRow?: (row: IJobOffer) => void;
+    onToggleRow?: (row: IJobOffer) => void;
+}
+
+export default function JobOfferDataTable({ offers, onEditRow, onDeleteRow, onToggleRow }: Props) {
+    const columns: ColumnDef<IJobOffer>[] = [
+        {
+            id: 'select',
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+                    onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                    aria-label="Select all"
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox checked={row.getIsSelected()} onCheckedChange={(value) => row.toggleSelected(!!value)} aria-label="Select row" />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+        },
+        {
+            accessorKey: 'title',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Titre
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
+            accessorKey: 'is_active',
+            header: 'Active',
+            cell: ({ row }) => (row.original.is_active ? 'Oui' : 'Non'),
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => <JobOfferActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} onToggle={onToggleRow} />,
+        },
+    ];
+
+    return <DataTable columns={columns} data={offers} filterColumn="title" />;
+}

--- a/resources/js/components/job-offers/jobOfferForm.tsx
+++ b/resources/js/components/job-offers/jobOfferForm.tsx
@@ -1,0 +1,83 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/text-area';
+import { IJobOffer } from '@/types';
+
+interface Props {
+    closeDrawer?: () => void;
+    initialData?: IJobOffer;
+}
+
+const defaultValues: IJobOffer = {
+    title: '',
+    company: '',
+    location: '',
+    type: '',
+    salary: 0,
+    description: '',
+    is_active: true,
+};
+
+export default function JobOfferForm({ closeDrawer, initialData }: Props) {
+    const { data, setData, processing, errors, reset } = useForm<IJobOffer>(initialData || defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        const routeUrl = initialData?.id
+            ? route('dashboard.job-offers.update', initialData.id)
+            : route('dashboard.job-offers.store');
+
+        router.visit(routeUrl, {
+            method: initialData?.id ? 'put' : 'post',
+            data: {
+                ...data,
+                is_active: data.is_active ? '1' : '0',
+            },
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Label htmlFor="title">Titre</Label>
+                <Input id="title" required value={data.title} onChange={(e) => setData('title', e.target.value)} disabled={processing} />
+                <InputError message={errors.title} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="company">Entreprise</Label>
+                <Input id="company" value={data.company} onChange={(e) => setData('company', e.target.value)} disabled={processing} />
+                <InputError message={errors.company} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="location">Localisation</Label>
+                <Input id="location" value={data.location} onChange={(e) => setData('location', e.target.value)} disabled={processing} />
+                <InputError message={errors.location} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="type">Type</Label>
+                <Input id="type" value={data.type} onChange={(e) => setData('type', e.target.value)} disabled={processing} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="salary">Salaire</Label>
+                <Input id="salary" type="number" value={data.salary || ''} onChange={(e) => setData('salary', Number(e.target.value))} disabled={processing} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea id="description" value={data.description} onChange={(e) => setData('description', e.target.value)} disabled={processing} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {initialData?.id ? 'Mettre à jour' : 'Créer'}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/job-offers/jobOfferToolBar.tsx
+++ b/resources/js/components/job-offers/jobOfferToolBar.tsx
@@ -1,0 +1,31 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface Props {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function JobOfferToolBar({ FormComponent, open, setOpen }: Props) {
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">Offres d'emploi</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label="Ajouter">
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && (
+                <Drawer title={'Ajouter une offre'} open={open} setOpen={setOpen && setOpen} component={FormComponent} />
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/job-offers/index.tsx
+++ b/resources/js/pages/dashboard/job-offers/index.tsx
@@ -1,0 +1,83 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, IJobOffer } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import JobOfferForm from '@/components/job-offers/jobOfferForm';
+import JobOfferToolBar from '@/components/job-offers/jobOfferToolBar';
+import JobOfferDataTable from '@/components/job-offers/jobOfferDataTable';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
+
+export default function DashboardJobOffers() {
+    const { data } = usePage<SharedData>().props;
+
+    const [offers, setOffers] = useState<IJobOffer[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<IJobOffer | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && Array.isArray((data as any).offers)) {
+            setOffers((data as any).offers);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.job-offers.delete', selected.id), {
+            onSuccess: () => {
+                toast.success('Offre supprimée');
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    const handleToggle = (row: IJobOffer) => {
+        router.post(route('dashboard.job-offers.toggle', row.id), {}, { preserveScroll: true });
+    };
+
+    const handleOpenEdit = (row: IJobOffer) => {
+        setSelected(row);
+        setOpenForm(true);
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Job Offers" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <JobOfferToolBar
+                    FormComponent={<JobOfferForm closeDrawer={() => setOpenForm(false)} initialData={selected} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={'Supprimer'}
+                    description={'Confirmer la suppression ?'}
+                    confirmLabel={'Supprimer'}
+                    cancelLabel={'Annuler'}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {offers && (
+                        <JobOfferDataTable
+                            offers={offers}
+                            onEditRow={handleOpenEdit}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                            onToggleRow={handleToggle}
+                        />
+                    )}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/public/careers/careers.tsx
+++ b/resources/js/pages/public/careers/careers.tsx
@@ -1,12 +1,11 @@
 import { JobList } from '@/components/careers/JobList';
-import { JobPostFormModal } from '@/components/careers/JobPostFormModal';
 import { JobSearchFilters } from '@/components/careers/JobSearchFilters';
 import ContactCard from '@/components/contactUs/ContactCard';
 import Hero from '@/components/hero/hearo';
 import { IHeroBreadcrumbItems } from '@/components/hero/HeroCourse';
 import MotionSection from '@/components/motion/MotionSection';
 import DefaultLayout from '@/layouts/public/front.layout';
-import { SharedData } from '@/types';
+import { SharedData, IJobOffer } from '@/types';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { usePage } from '@inertiajs/react';
 import { motion, Variants } from 'framer-motion';
@@ -14,43 +13,9 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // Types pour les offres d'emploi
-export interface JobOffer {
-    id: string;
-    title: string;
-    company: string;
-    location: string;
-    type: 'CDI' | 'CDD' | 'Freelance' | 'Stage';
-    salary: number;
-    description: string;
-    postedAt: string;
-}
-
-// Données fictives pour les offres (à remplacer par une API)
-export const mockJobs: JobOffer[] = [
-    {
-        id: '1',
-        title: 'Développeur Full Stack',
-        company: 'TechCorp',
-        location: 'Paris, France',
-        type: 'CDI',
-        salary: 60000,
-        description: 'Rejoignez notre équipe pour développer des applications web modernes.',
-        postedAt: '2025-06-20',
-    },
-    {
-        id: '2',
-        title: 'Designer UX/UI',
-        company: 'DesignLab',
-        location: 'Lyon, France',
-        type: 'Freelance',
-        salary: 50000,
-        description: 'Créez des interfaces utilisateur intuitives et attrayantes.',
-        postedAt: '2025-06-18',
-    },
-];
 
 export default function Careers() {
-    const { auth } = usePage<SharedData>().props;
+    const { auth, data } = usePage<SharedData>().props;
     const { t } = useTranslation();
 
     const pageTitle = t('PAGES.CAREERS', 'Carrières');
@@ -60,9 +25,8 @@ export default function Careers() {
         { label: t('PAGES.CAREERS', pageTitle), href: '#' },
     ];
 
-    const [jobs, setJobs] = useState<JobOffer[]>(mockJobs);
+    const [jobs, setJobs] = useState<IJobOffer[]>(data.job_offers as IJobOffer[]);
     const [filters, setFilters] = useState({ title: '', location: '', type: '', minSalary: 0 });
-    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const filteredJobs = jobs.filter((job) => {
         return (
@@ -73,14 +37,6 @@ export default function Careers() {
         );
     });
 
-    const handlePostJob = (newJob: Omit<JobOffer, 'id' | 'postedAt'>) => {
-        const job: JobOffer = {
-            ...newJob,
-            id: String(jobs.length + 1),
-            postedAt: new Date().toISOString().split('T')[0],
-        };
-        setJobs([...jobs, job]);
-    };
 
     const pageVariants: Variants = {
         hidden: { opacity: 0 },
@@ -108,18 +64,11 @@ export default function Careers() {
                         animate="visible"
                     >
                         <div className="max-w-7xl mx-auto">
-                            <div className="flex justify-between items-center mb-6">
+                            <div className="mb-6">
                                 <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">Offres d'emploi</h1>
-                                <button
-                                    onClick={() => setIsModalOpen(true)}
-                                    className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600"
-                                >
-                                    Publier une offre
-                                </button>
                             </div>
                             <JobSearchFilters onFilterChange={setFilters} />
                             <JobList jobs={filteredJobs} />
-                            <JobPostFormModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} onSubmit={handlePostJob} />
                         </div>
                     </motion.div>
                 </MotionSection>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -71,3 +71,4 @@ export interface IDataWithPagination<T> {
 export * from './reference';
 export * from './partner';
 export * from './notification';
+export * from './job-offer';

--- a/resources/js/types/job-offer.d.ts
+++ b/resources/js/types/job-offer.d.ts
@@ -1,0 +1,19 @@
+export interface IJobOffer {
+    id?: number;
+    title: string;
+    company?: string;
+    location?: string;
+    type?: string;
+    salary?: number;
+    description?: string;
+    is_active?: boolean;
+    created_at?: string;
+    updated_at?: string;
+}
+
+export interface IJobApplication {
+    job_offer_id: number;
+    name: string;
+    email: string;
+    message?: string;
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Private\SettingController;
 use App\Http\Controllers\Private\TestimonialController;
 use App\Http\Controllers\Private\ReferenceController;
 use App\Http\Controllers\Private\PartnerController;
+use App\Http\Controllers\Private\JobOfferController;
 use App\Http\Controllers\Private\EnrollmentController;
 use App\Http\Controllers\Private\NotificationController;
 use App\Http\Controllers\Settings\PasswordController;
@@ -139,6 +140,18 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::put('update/{reference}', [ReferenceController::class, 'update'])->name('dashboard.references.update');
         Route::delete('delete/{reference}', [ReferenceController::class, 'destroy'])->name('dashboard.references.delete');
         Route::post('restore/{reference}', [ReferenceController::class, 'restore'])->name('dashboard.references.restore');
+    });
+
+    // JOB OFFERS
+    Route::group([
+        'prefix' => 'job-offers',
+    ], function () {
+        Route::get('', [JobOfferController::class, 'index'])->name('dashboard.job-offers.index');
+        Route::post('create', [JobOfferController::class, 'store'])->name('dashboard.job-offers.store');
+        Route::put('update/{jobOffer}', [JobOfferController::class, 'update'])->name('dashboard.job-offers.update');
+        Route::delete('delete/{jobOffer}', [JobOfferController::class, 'destroy'])->name('dashboard.job-offers.delete');
+        Route::post('restore/{jobOffer}', [JobOfferController::class, 'restore'])->name('dashboard.job-offers.restore');
+        Route::post('toggle/{jobOffer}', [JobOfferController::class, 'toggle'])->name('dashboard.job-offers.toggle');
     });
 
     // PARTNERS

--- a/routes/front.php
+++ b/routes/front.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Public\ContactUsController;
 use App\Http\Controllers\Public\EnrollController;
 use App\Http\Controllers\Public\PublicController;
+use App\Http\Controllers\Public\PublicJobController;
 use App\Http\Controllers\Public\PublicFormationController;
 use App\Http\Controllers\Public\PublicFormationSessionController;
 use Illuminate\Support\Facades\Route;
@@ -54,7 +55,8 @@ Route::group(["prefix" => "/"], function () {
     /**
      * Careers routes
      */
-    Route::get('careers', [PublicController::class, 'careers'])->name('careers');
+    Route::get('careers', [PublicJobController::class, 'list'])->name('careers');
+    Route::post('job/apply', [PublicJobController::class, 'apply'])->name('job.apply');
     Route::get('job/{job_slug}', [PublicController::class, 'jobDetail'])->name('job.detail');
 
     /**


### PR DESCRIPTION
## Summary
- add migrations and models for job offers and applications
- implement repositories and controllers
- expose dashboard CRUD routes and public routes
- provide React components for listing and applying to job offers
- update careers page to load offers from the backend

## Testing
- `composer install --ignore-platform-req=ext-sodium` *(failed due to network restrictions but continued)*
- ❌ `composer install` *(failed: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_6872225eda808333b6160c079d294dee