### PR TITLE
Add services overview page

### DIFF
--- a/app/Http/Controllers/Public/PublicController.php
+++ b/app/Http/Controllers/Public/PublicController.php
@@ -80,8 +80,11 @@ class PublicController extends PublicAbstractController
 
     public function services()
     {
-        // Services
-        return view('services');
+        $data = $this->default_data;
+
+        return Inertia::render('public/services', [
+            'data' => $data,
+        ]);
     }
 
     public function blogs()

--- a/resources/js/data/data.constant.ts
+++ b/resources/js/data/data.constant.ts
@@ -34,7 +34,7 @@ export const DEFULAT_MAIN_MENU: IMainMenuItem[] = [
     {
         id: 'servies',
         label: 'Offre pour entreprises',
-        href: ROUTE_MAP.public.services.testSerivces.index.link,
+        href: ROUTE_MAP.public.services.index.link,
         featureImage: '/assets/images/feature_image.png',
         gridClass: 'grid-cols-1 lg:grid-cols-3',
         maxWidth: 'w-[900px]',

--- a/resources/js/pages/public/services.tsx
+++ b/resources/js/pages/public/services.tsx
@@ -1,0 +1,40 @@
+import AboutUsServices from '@/components/aboutUs/AboutUsServices';
+import Hero, { IHeroBreadcrumbItems } from '@/components/hero/hearo';
+import DefaultLayout from '@/layouts/public/front.layout';
+import { type SharedData } from '@/types';
+import { ROUTE_MAP } from '@/utils/route.util';
+import { usePage } from '@inertiajs/react';
+import { useTranslation } from 'react-i18next';
+
+export default function ServicesPage() {
+    const { auth } = usePage<SharedData>().props;
+    const { t } = useTranslation();
+
+    const breadcrumbItems: IHeroBreadcrumbItems[] = [
+        { label: t('PAGES.HOME', 'Accueil'), href: ROUTE_MAP.public.home.link },
+        { label: t('PAGES.SERVICES', 'Nos services'), href: '#' },
+    ];
+
+    return (
+        <DefaultLayout
+            title={t('PAGES.SERVICES', 'Nos services')}
+            description={t(
+                'PAGES.SERVICES_DESCRIPTION',
+                "Découvrez comment notre expertise peut accompagner votre entreprise."
+            )}
+        >
+            <div className="bg-gray-100 dark:bg-[#0a0e19]">
+                <Hero
+                    title={t('PAGES.SERVICES', 'Nos services')}
+                    description={t(
+                        'PAGES.SERVICES_DESCRIPTION',
+                        "Découvrez comment notre expertise peut accompagner votre entreprise."
+                    )}
+                    breadcrumbItems={breadcrumbItems}
+                    gradient="style-3"
+                />
+                <AboutUsServices />
+            </div>
+        </DefaultLayout>
+    );
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -46,6 +46,7 @@ interface IROUTE_MAP {
             detail: (categorySlug: string, slug: string) => IRouteMap;
         };
         services: {
+            index: IRouteMap;
             consulting: {
                 index: IRouteMap;
                 auditOfMaturityOfTests: IRouteMap;
@@ -109,6 +110,7 @@ export const ROUTE_MAP: IROUTE_MAP = {
             }
         },
         services: {
+            index: createIRouteMap(route('services'), 'Nos services'),
             consulting: {
                 index: createIRouteMap(route('consulting'), 'Consulting'),
                 auditOfMaturityOfTests: createIRouteMap(route('consulting.audit'), 'Audit de maturité de tests'),


### PR DESCRIPTION
## Summary
- create a Services page with hero and service listings
- hook PublicController to render the new page
- expose `/services` in route map
- point header menu item to the services overview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format:check` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `composer test` *(fails: could not find vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68722bd26de08333b43f18d5cf459d26