### PR TITLE
Enhance newsletter management

### DIFF
--- a/app/Http/Controllers/Private/NewsletterController.php
+++ b/app/Http/Controllers/Private/NewsletterController.php
@@ -2,17 +2,57 @@
 
 namespace App\Http\Controllers\Private;
 
-use App\Events\SubscriberMailEvent;
 use App\Http\Controllers\Controller;
-use App\Models\NewsletterSubscriber;
+use App\Http\Requests\NewsletterStoreRequest;
+use App\Mail\Newslatter;
+use App\Models\Newsletter;
+use App\Models\NewsletterLog;
+use App\Models\NewsletterTemplate;
+use App\Repositories\NewsletterRepository;
+use App\Repositories\NewsletterTemplateRepository;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
 
 class NewsletterController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        return Inertia::render('dashboard/newsletter/index');
+        $search = $request->search ? strtolower($request->search) : null;
+
+        $newsletters = NewsletterRepository::query()
+            ->when($search, fn($query) => $query->where('email', 'like', "%{$search}%"))
+            ->latest('id')
+            ->paginate(15)
+            ->withQueryString();
+
+        return Inertia::render('dashboard/newsletters/index', [
+            'data' => [
+                'newsletters' => $newsletters,
+            ],
+        ]);
+    }
+
+    public function store(NewsletterStoreRequest $request)
+    {
+        NewsletterRepository::storeByRequest($request);
+        return to_route('dashboard.newsletters.index')->with('success', 'Newsletter created');
+    }
+
+    public function destroy(Newsletter $newsletter)
+    {
+        $newsletter->delete();
+        return to_route('dashboard.newsletters.index')->with('success', 'Newsletter deleted');
+    }
+
+    public function compose()
+    {
+        $templates = NewsletterTemplateRepository::query()->get();
+        return Inertia::render('dashboard/newsletter/index', [
+            'data' => [
+                'templates' => $templates,
+            ],
+        ]);
     }
 
     public function send(Request $request)
@@ -22,10 +62,26 @@ class NewsletterController extends Controller
             'content' => 'required|string',
         ]);
 
-        $emails = NewsletterSubscriber::pluck('email');
+        $emails = Newsletter::pluck('email');
 
         foreach ($emails as $email) {
-            SubscriberMailEvent::dispatch($email, $validated['subject'], $validated['content']);
+            $log = NewsletterLog::create([
+                'email' => $email,
+                'subject' => $validated['subject'],
+                'content' => $validated['content'],
+            ]);
+
+            try {
+                Mail::to($email)->send(new Newslatter($validated['subject'], $validated['content']));
+                $log->update([
+                    'is_sent' => true,
+                    'sent_at' => now(),
+                ]);
+            } catch (\Exception $e) {
+                $log->update([
+                    'error' => $e->getMessage(),
+                ]);
+            }
         }
 
         return back()->with('success', 'Newsletter envoyée');

--- a/app/Http/Controllers/Private/NewsletterLogController.php
+++ b/app/Http/Controllers/Private/NewsletterLogController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Mail\Newslatter;
+use App\Models\NewsletterLog;
+use Illuminate\Support\Facades\Mail;
+use Inertia\Inertia;
+
+class NewsletterLogController extends Controller
+{
+    public function index()
+    {
+        $logs = NewsletterLog::latest('id')->paginate(20);
+        return Inertia::render('dashboard/newsletter-logs/index', [
+            'data' => [
+                'logs' => $logs,
+            ],
+        ]);
+    }
+
+    public function resend(NewsletterLog $newsletterLog)
+    {
+        try {
+            Mail::to($newsletterLog->email)->send(new Newslatter($newsletterLog->subject, $newsletterLog->content));
+            $newsletterLog->update([
+                'is_sent' => true,
+                'sent_at' => now(),
+                'error' => null,
+            ]);
+        } catch (\Exception $e) {
+            $newsletterLog->update([
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return back()->with('success', 'Mail sent');
+    }
+}

--- a/app/Http/Controllers/Private/NewsletterTemplateController.php
+++ b/app/Http/Controllers/Private/NewsletterTemplateController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\NewsletterTemplateStoreRequest;
+use App\Models\NewsletterTemplate;
+use App\Repositories\NewsletterTemplateRepository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class NewsletterTemplateController extends Controller
+{
+    public function index()
+    {
+        $templates = NewsletterTemplateRepository::query()->latest('id')->get();
+        return Inertia::render('dashboard/newsletter-templates/index', [
+            'data' => [
+                'templates' => $templates,
+            ],
+        ]);
+    }
+
+    public function store(NewsletterTemplateStoreRequest $request)
+    {
+        NewsletterTemplateRepository::create($request->only(['name', 'subject', 'content']));
+        return to_route('dashboard.newsletter-templates.index')->with('success', 'Template created');
+    }
+
+    public function destroy(NewsletterTemplate $newsletterTemplate)
+    {
+        $newsletterTemplate->delete();
+        return to_route('dashboard.newsletter-templates.index')->with('success', 'Template deleted');
+    }
+}

--- a/app/Http/Requests/NewsletterTemplateStoreRequest.php
+++ b/app/Http/Requests/NewsletterTemplateStoreRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NewsletterTemplateStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string',
+            'subject' => 'required|string',
+            'content' => 'required|string',
+        ];
+    }
+}

--- a/app/Models/NewsletterLog.php
+++ b/app/Models/NewsletterLog.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class NewsletterLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'email',
+        'subject',
+        'content',
+        'is_sent',
+        'sent_at',
+        'error',
+    ];
+
+    protected $casts = [
+        'is_sent' => 'boolean',
+        'sent_at' => 'datetime',
+    ];
+}

--- a/app/Models/NewsletterTemplate.php
+++ b/app/Models/NewsletterTemplate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class NewsletterTemplate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'subject',
+        'content',
+    ];
+}

--- a/app/Repositories/NewsletterLogRepository.php
+++ b/app/Repositories/NewsletterLogRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\NewsletterLog;
+
+class NewsletterLogRepository extends Repository
+{
+    public static function model()
+    {
+        return NewsletterLog::class;
+    }
+}

--- a/app/Repositories/NewsletterTemplateRepository.php
+++ b/app/Repositories/NewsletterTemplateRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Repositories;
+
+use Abedin\Maker\Repositories\Repository;
+use App\Models\NewsletterTemplate;
+
+class NewsletterTemplateRepository extends Repository
+{
+    public static function model()
+    {
+        return NewsletterTemplate::class;
+    }
+}

--- a/database/migrations/2025_07_12_060000_create_newsletter_templates_table.php
+++ b/database/migrations/2025_07_12_060000_create_newsletter_templates_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('newsletter_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('subject');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('newsletter_templates');
+    }
+};

--- a/database/migrations/2025_07_12_060100_create_newsletter_logs_table.php
+++ b/database/migrations/2025_07_12_060100_create_newsletter_logs_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('newsletter_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('email');
+            $table->string('subject');
+            $table->text('content');
+            $table->boolean('is_sent')->default(false);
+            $table->timestamp('sent_at')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('newsletter_logs');
+    }
+};

--- a/resources/js/components/newsletter/logDataTable.tsx
+++ b/resources/js/components/newsletter/logDataTable.tsx
@@ -1,0 +1,46 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, RotateCw } from 'lucide-react';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import { INewsletterLog } from '@/types/newsletterLog';
+
+interface Props {
+    logs: INewsletterLog[];
+    onResend?: (row: INewsletterLog) => void;
+}
+
+export default function LogDataTable({ logs, onResend }: Props) {
+    const columns: ColumnDef<INewsletterLog>[] = [
+        {
+            accessorKey: 'email',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Email
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
+            accessorKey: 'subject',
+            header: 'Subject',
+        },
+        {
+            accessorKey: 'is_sent',
+            header: 'Sent',
+            cell: ({ row }) => (row.original.is_sent ? 'Yes' : 'No'),
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => (
+                !row.original.is_sent && (
+                    <Button variant="ghost" size="icon" onClick={() => onResend?.(row.original)}>
+                        <RotateCw className="h-4 w-4" />
+                    </Button>
+                )
+            ),
+        },
+    ];
+
+    return <DataTable columns={columns} data={logs} filterColumn="email" />;
+}

--- a/resources/js/components/newsletter/templateDataTable.tsx
+++ b/resources/js/components/newsletter/templateDataTable.tsx
@@ -1,0 +1,39 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, Trash2 } from 'lucide-react';
+import { DataTable } from '../ui/dataTable';
+import { Button } from '../ui/button/button';
+import { INewsletterTemplate } from '@/types/newsletterTemplate';
+
+interface Props {
+    templates: INewsletterTemplate[];
+    onDeleteRow?: (row: INewsletterTemplate) => void;
+}
+
+export default function TemplateDataTable({ templates, onDeleteRow }: Props) {
+    const columns: ColumnDef<INewsletterTemplate>[] = [
+        {
+            accessorKey: 'name',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Name
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
+            accessorKey: 'subject',
+            header: 'Subject',
+        },
+        {
+            id: 'actions',
+            enableHiding: false,
+            cell: ({ row }) => (
+                <Button variant="ghost" size="icon" onClick={() => onDeleteRow?.(row.original)}>
+                    <Trash2 className="text-red-600 h-4 w-4" />
+                </Button>
+            ),
+        },
+    ];
+
+    return <DataTable columns={columns} data={templates} filterColumn="name" />;
+}

--- a/resources/js/components/newsletter/templateForm.tsx
+++ b/resources/js/components/newsletter/templateForm.tsx
@@ -1,0 +1,55 @@
+import { router, useForm } from '@inertiajs/react';
+import { FormEventHandler } from 'react';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/text-area';
+import { INewsletterTemplate } from '@/types/newsletterTemplate';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+    closeDrawer?: () => void;
+}
+
+const defaultValues: INewsletterTemplate = {
+    name: '',
+    subject: '',
+    content: '',
+};
+
+export default function TemplateForm({ closeDrawer }: Props) {
+    const { t } = useTranslation();
+    const { data, setData, processing, errors, reset } = useForm<INewsletterTemplate>(defaultValues);
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        router.post(route('dashboard.newsletter-templates.store'), data, {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                reset();
+                closeDrawer?.();
+            },
+        });
+    };
+
+    return (
+        <form className="mx-auto flex max-w-xl flex-col gap-4" onSubmit={submit}>
+            <div className="grid gap-2">
+                <Input id="name" required value={data.name} onChange={(e) => setData('name', e.target.value)} disabled={processing} placeholder="Name" />
+                <InputError message={errors.name} />
+            </div>
+            <div className="grid gap-2">
+                <Input id="subject" required value={data.subject} onChange={(e) => setData('subject', e.target.value)} disabled={processing} placeholder="Subject" />
+                <InputError message={errors.subject} />
+            </div>
+            <div className="grid gap-2">
+                <Textarea id="content" required value={data.content} onChange={(e) => setData('content', e.target.value)} disabled={processing} placeholder="Content" />
+                <InputError message={errors.content} />
+            </div>
+            <Button type="submit" className="mt-2 w-full" disabled={processing}>
+                {t('Create', 'Créer')}
+            </Button>
+        </form>
+    );
+}

--- a/resources/js/components/newsletter/templateToolBar.tsx
+++ b/resources/js/components/newsletter/templateToolBar.tsx
@@ -1,0 +1,32 @@
+import { JSX } from 'react';
+import { CirclePlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button/button';
+import Drawer from '../ui/drawer';
+
+interface Props {
+    open?: boolean;
+    setOpen?: (open: boolean) => void;
+    FormComponent?: JSX.Element;
+}
+
+export default function TemplateToolBar({ FormComponent, open, setOpen }: Props) {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <header className="mb-4 rounded-lg p-4">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-bold">{t('Templates')}</h1>
+                    <div className="mt-2 flex justify-end space-x-2">
+                        <Button className="cursor-pointer rounded bg-gray-600 p-2" onClick={() => setOpen && setOpen(true)} aria-label={t('Add template', 'Ajouter')}>
+                            <CirclePlus className="h-5 w-5" />
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            {open && FormComponent && <Drawer title={t('Add template', 'Ajouter')} open={open} setOpen={setOpen && setOpen} component={FormComponent} />}
+        </div>
+    );
+}

--- a/resources/js/pages/dashboard/newsletter-logs/index.tsx
+++ b/resources/js/pages/dashboard/newsletter-logs/index.tsx
@@ -1,0 +1,51 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import LogDataTable from '@/components/newsletter/logDataTable';
+import { INewsletterLog } from '@/types/newsletterLog';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Logs',
+        href: '/dashboard/newsletter-logs',
+    },
+    {
+        title: 'Dashboard',
+        href: route('dashboard.index'),
+    },
+];
+
+export default function NewsletterLogs() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+
+    const [logs, setLogs] = useState<INewsletterLog[]>([]);
+
+    useEffect(() => {
+        if (data && Array.isArray(data.logs)) {
+            setLogs(data.logs as any);
+        }
+    }, [data]);
+
+    const handleResend = (log: INewsletterLog) => {
+        router.post(route('dashboard.newsletter-logs.resend', log.id), {}, {
+            onSuccess: () => {
+                toast.success(t('mail.resent', 'Mail renvoyé'));
+            },
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Newsletter Logs" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {logs && <LogDataTable logs={logs} onResend={handleResend} />}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/dashboard/newsletter-templates/index.tsx
+++ b/resources/js/pages/dashboard/newsletter-templates/index.tsx
@@ -1,0 +1,86 @@
+import AppLayout from '@/layouts/dashboard/app-layout';
+import { SharedData, type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import TemplateForm from '@/components/newsletter/templateForm';
+import TemplateToolBar from '@/components/newsletter/templateToolBar';
+import TemplateDataTable from '@/components/newsletter/templateDataTable';
+import { INewsletterTemplate } from '@/types/newsletterTemplate';
+import { ConfirmDialog } from '@/components/ui/confirmDialog';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Templates',
+        href: '/dashboard/newsletter-templates',
+    },
+    {
+        title: 'Dashboard',
+        href: route('dashboard.index'),
+    },
+];
+
+export default function NewsletterTemplates() {
+    const { t } = useTranslation();
+    const { data } = usePage<SharedData>().props;
+
+    const [templates, setTemplates] = useState<INewsletterTemplate[]>([]);
+    const [openForm, setOpenForm] = useState(false);
+    const [selected, setSelected] = useState<INewsletterTemplate | undefined>(undefined);
+    const [showConfirm, setShowConfirm] = useState(false);
+
+    useEffect(() => {
+        if (data && Array.isArray(data.templates)) {
+            setTemplates(data.templates as any);
+        }
+    }, [data]);
+
+    const handleDelete = () => {
+        if (!selected) return;
+        router.delete(route('dashboard.newsletter-templates.delete', selected.id), {
+            onSuccess: () => {
+                toast.success(t('template.deleted', 'Template supprimé'));
+                setShowConfirm(false);
+            },
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Newsletter Templates" />
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <TemplateToolBar
+                    FormComponent={<TemplateForm closeDrawer={() => setOpenForm(false)} />}
+                    open={openForm}
+                    setOpen={(o) => {
+                        setOpenForm(o);
+                        if (!o) setSelected(undefined);
+                    }}
+                />
+
+                <ConfirmDialog
+                    open={showConfirm}
+                    title={t('Delete template', 'Supprimer le template')}
+                    description={t('Are you sure?', 'Voulez-vous vraiment supprimer ?')}
+                    confirmLabel={t('Delete', 'Supprimer')}
+                    cancelLabel={t('Cancel', 'Annuler')}
+                    onConfirm={handleDelete}
+                    onCancel={() => setShowConfirm(false)}
+                />
+
+                <div className="container mx-auto flex h-full items-center justify-center">
+                    {templates && (
+                        <TemplateDataTable
+                            templates={templates}
+                            onDeleteRow={(row) => {
+                                setSelected(row);
+                                setShowConfirm(true);
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/dashboard/newsletter/index.tsx
+++ b/resources/js/pages/dashboard/newsletter/index.tsx
@@ -1,15 +1,35 @@
 import AppLayout from '@/layouts/dashboard/app-layout';
-import { Head, router } from '@inertiajs/react';
-import { useState } from 'react';
+import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/text-area';
 import { useTranslation } from 'react-i18next';
+import { INewsletterTemplate } from '@/types/newsletterTemplate';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 export default function NewsletterIndex() {
     const { t } = useTranslation();
+    const { data } = usePage<{ data: { templates: INewsletterTemplate[] } }>().props;
+
     const [subject, setSubject] = useState('');
     const [content, setContent] = useState('');
+    const [templates, setTemplates] = useState<INewsletterTemplate[]>([]);
+    const [templateId, setTemplateId] = useState<string>('');
+
+    useEffect(() => {
+        if (data && Array.isArray(data.templates)) {
+            setTemplates(data.templates);
+        }
+    }, [data]);
+
+    useEffect(() => {
+        const tpl = templates.find((t) => t.id?.toString() === templateId);
+        if (tpl) {
+            setSubject(tpl.subject);
+            setContent(tpl.content);
+        }
+    }, [templateId, templates]);
 
     const submit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -20,6 +40,22 @@ export default function NewsletterIndex() {
         <AppLayout breadcrumbs={[{ title: 'Newsletters', href: '/dashboard/newsletters' }]}>
             <Head title="Newsletters" />
             <form onSubmit={submit} className="flex flex-col gap-4 p-4 max-w-xl">
+                {templates.length > 0 && (
+                    <Select value={templateId} onValueChange={setTemplateId}>
+                        <SelectTrigger>
+                            <SelectValue placeholder={t('Choose template', 'Choisir un template')} />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectGroup>
+                                {templates.map((tpl) => (
+                                    <SelectItem key={tpl.id} value={tpl.id!.toString()}>
+                                        {tpl.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectGroup>
+                        </SelectContent>
+                    </Select>
+                )}
                 <Input
                     value={subject}
                     onChange={(e) => setSubject(e.target.value)}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -72,3 +72,5 @@ export * from './reference';
 export * from './partner';
 export * from './notification';
 export * from './job-offer';
+export * from './newsletterTemplate';
+export * from './newsletterLog';

--- a/resources/js/types/newsletterLog.d.ts
+++ b/resources/js/types/newsletterLog.d.ts
@@ -1,0 +1,11 @@
+export interface INewsletterLog {
+    id?: number;
+    email: string;
+    subject: string;
+    content: string;
+    is_sent?: boolean;
+    sent_at?: string | null;
+    error?: string | null;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/resources/js/types/newsletterTemplate.d.ts
+++ b/resources/js/types/newsletterTemplate.d.ts
@@ -1,0 +1,8 @@
+export interface INewsletterTemplate {
+    id?: number;
+    name: string;
+    subject: string;
+    content: string;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -152,6 +152,9 @@ export const ROUTE_MAP: IROUTE_MAP = {
         },
         newsletters: {
             index: createIRouteMap(route('dashboard.newsletters.index'), 'Newsletters'),
+            compose: createIRouteMap(route('dashboard.newsletters.compose'), 'Compose'),
+            templates: createIRouteMap(route('dashboard.newsletter-templates.index'), 'Templates'),
+            logs: createIRouteMap(route('dashboard.newsletter-logs.index'), 'Logs'),
         },
     }
 }

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Private\CourseController;
 use App\Http\Controllers\Private\DashboardController;
 use App\Http\Controllers\Private\FaqController;
 use App\Http\Controllers\Private\NewsletterController;
+use App\Http\Controllers\Private\NewsletterTemplateController;
+use App\Http\Controllers\Private\NewsletterLogController;
 use App\Http\Controllers\Private\SettingController;
 use App\Http\Controllers\Private\TestimonialController;
 use App\Http\Controllers\Private\ReferenceController;
@@ -171,8 +173,26 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         'prefix' => 'newsletters',
     ], function () {
         Route::get('', [NewsletterController::class, 'index'])->name('dashboard.newsletters.index');
+        Route::get('compose', [NewsletterController::class, 'compose'])->name('dashboard.newsletters.compose');
         Route::post('send', [NewsletterController::class, 'send'])->name('dashboard.newsletters.send');
         Route::post('create', [NewsletterController::class, 'store'])->name('dashboard.newsletters.store');
         Route::delete('delete/{newsletter}', [NewsletterController::class, 'destroy'])->name('dashboard.newsletters.delete');
+    });
+
+    // NEWSLETTER TEMPLATES
+    Route::group([
+        'prefix' => 'newsletter-templates',
+    ], function () {
+        Route::get('', [NewsletterTemplateController::class, 'index'])->name('dashboard.newsletter-templates.index');
+        Route::post('create', [NewsletterTemplateController::class, 'store'])->name('dashboard.newsletter-templates.store');
+        Route::delete('delete/{newsletterTemplate}', [NewsletterTemplateController::class, 'destroy'])->name('dashboard.newsletter-templates.delete');
+    });
+
+    // NEWSLETTER LOGS
+    Route::group([
+        'prefix' => 'newsletter-logs',
+    ], function () {
+        Route::get('', [NewsletterLogController::class, 'index'])->name('dashboard.newsletter-logs.index');
+        Route::post('resend/{newsletterLog}', [NewsletterLogController::class, 'resend'])->name('dashboard.newsletter-logs.resend');
     });
 });


### PR DESCRIPTION
## Summary
- add newsletter template and log migrations
- add models and repositories for templates and logs
- enhance newsletter controller with subscriber listing, composing, sending with logs
- add controllers for managing templates and viewing logs
- add React components and pages for templates and logs
- update routes and client utilities

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68722c4ea61c83339cea2996ea2bd8bb