### PR TITLE
Add inline search to results page

### DIFF
--- a/resources/js/pages/public/search.page.tsx
+++ b/resources/js/pages/public/search.page.tsx
@@ -5,8 +5,11 @@ import { SharedData } from '@/types';
 import { ICourse } from '@/types/course';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { usePage } from '@inertiajs/react';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button/button';
 
 interface PageProps extends SharedData {
     data: {
@@ -19,6 +22,8 @@ export default function SearchPage() {
     const { t } = useTranslation();
     const { data, searchTerm } = usePage<PageProps>().props;
     const [courses, setCourses] = useState<ICourse[]>([]);
+    const [searchText, setSearchText] = useState<string>(searchTerm);
+    const [loading, setLoading] = useState<boolean>(false);
 
     const breadcrumb: IHeroBreadcrumbItems[] = [
         { label: 'Home', href: ROUTE_MAP.public.home.link },
@@ -31,16 +36,51 @@ export default function SearchPage() {
         }
     }, [data]);
 
+    const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (searchText.trim() === '') {
+            setCourses([]);
+            return;
+        }
+        setLoading(true);
+        axios
+            .post(route('search'), { search: searchText })
+            .then((response: { data: { search_result: { courses?: ICourse[] } } }) => {
+                setCourses(response.data.search_result.courses || []);
+                setLoading(false);
+            })
+            .catch(() => {
+                setLoading(false);
+            });
+    };
+
     return (
         <DefaultLayout title={t('HEADER.SEARCH_RESULTS', 'Résultats de recherche')}>
             <div className="bg-gray-100 dark:bg-[#0a0e19]">
                 <Hero
                     title={t('HEADER.SEARCH_RESULTS', 'Résultats de recherche')}
-                    description={searchTerm}
+                    description={searchText}
                     breadcrumbItems={breadcrumb}
                 />
                 <div className="container mx-auto p-4">
-                    <CourseTable courses={courses} />
+                    <form onSubmit={handleSearch} className="mb-4 flex gap-2">
+                        <Input
+                            type="text"
+                            placeholder={t('HEADER.SEARCH_PLACEHOLDER', 'Rechercher...')}
+                            value={searchText}
+                            onChange={(e) => setSearchText(e.target.value)}
+                        />
+                        <Button type="submit" disabled={loading}>
+                            {t('HEADER.SEARCH', 'Rechercher')}
+                        </Button>
+                    </form>
+                    {loading ? (
+                        <div className="flex justify-center py-10">
+                            <span>{t('LOADING', 'Chargement...')}</span>
+                        </div>
+                    ) : (
+                        <CourseTable courses={courses} />
+                    )}
                 </div>
             </div>
         </DefaultLayout>


### PR DESCRIPTION
## Summary
- add search text state and loading state
- update search page to include a search form
- fetch results with axios and render them directly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `composer install` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_68722c8126708333b49c3a1b927ba2a6