### PR TITLE
Add course view counter and display popular courses

### DIFF
--- a/app/Http/Controllers/Private/DashboardController.php
+++ b/app/Http/Controllers/Private/DashboardController.php
@@ -69,22 +69,14 @@ class DashboardController extends PrivateAbstractController
             $chartData[] = isset($enrollmentData[$month]) ? $enrollmentData[$month] : 0;
         }
 
-        // Fetch courses created data for the current year, grouped by month
-        $courseData = Course::select(
-            DB::raw('MONTH(created_at) as month'),
-            DB::raw('COUNT(*) as count')
-        )
-            ->whereYear('created_at', $currentYear)
-            ->groupBy(DB::raw('MONTH(created_at)'))
-            ->orderBy('month')
-            ->get()
-            ->pluck('count', 'month')
-            ->toArray();
+        // Fetch top viewed courses
+        $popularCourses = Course::where('is_published', 1)
+            ->orderByDesc('view_count')
+            ->limit(10)
+            ->get(['title', 'view_count']);
 
-        $courseChartData = [];
-        for ($month = 1; $month <= 12; $month++) {
-            $courseChartData[] = isset($courseData[$month]) ? $courseData[$month] : 0;
-        }
+        $courseChartData = $popularCourses->pluck('view_count')->toArray();
+        $courseChartCategories = $popularCourses->pluck('title')->toArray();
 
         $chart_data = [
             'enrollment_area' => [
@@ -112,24 +104,11 @@ class DashboardController extends PrivateAbstractController
             'course_area' => [
                 'series' => [
                     [
-                        'name' => 'Courses',
+                        'name' => 'Views',
                         'data' => $courseChartData,
                     ],
                 ],
-                'categories' => [
-                    "$currentYear-01-01T00:00:00.000Z",
-                    "$currentYear-02-01T00:00:00.000Z",
-                    "$currentYear-03-01T00:00:00.000Z",
-                    "$currentYear-04-01T00:00:00.000Z",
-                    "$currentYear-05-01T00:00:00.000Z",
-                    "$currentYear-06-01T00:00:00.000Z",
-                    "$currentYear-07-01T00:00:00.000Z",
-                    "$currentYear-08-01T00:00:00.000Z",
-                    "$currentYear-09-01T00:00:00.000Z",
-                    "$currentYear-10-01T00:00:00.000Z",
-                    "$currentYear-11-01T00:00:00.000Z",
-                    "$currentYear-12-01T00:00:00.000Z",
-                ],
+                'categories' => $courseChartCategories,
             ],
         ];
 

--- a/app/Http/Controllers/Public/PublicFormationController.php
+++ b/app/Http/Controllers/Public/PublicFormationController.php
@@ -135,6 +135,9 @@ class PublicFormationController extends PublicAbstractController
                 return redirect()->route('courses')->withErrors('Introuvable');
             }
 
+            // Increment view count for the course
+            CourseRepository::incrementViewCount($course);
+
             $data = $this->default_data;
             $category = CategoryRepository::findBySlug($categorySlug);
 

--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -122,6 +122,11 @@ class CourseRepository extends Repository
         }
     }
 
+    public static function incrementViewCount(Course $course): void
+    {
+        $course->increment('view_count');
+    }
+
     /**
      * Get all courses by category id.
      *

--- a/resources/js/components/charts/EnrollmentRateAreaChart.tsx
+++ b/resources/js/components/charts/EnrollmentRateAreaChart.tsx
@@ -30,7 +30,7 @@ const EnrollmentRateAreaChart: React.FC<AreaChartProps> = ({ title = 'Chart', se
         },
         colors: ['#605DFF', '#0f79f3'],
         xaxis: {
-            type: 'datetime',
+            type: 'category',
             categories,
             axisTicks: {
                 show: false,
@@ -48,11 +48,7 @@ const EnrollmentRateAreaChart: React.FC<AreaChartProps> = ({ title = 'Chart', se
                 },
             },
         },
-        tooltip: {
-            x: {
-                format: 'dd/MM/yy HH:mm',
-            },
-        },
+        tooltip: {},
         yaxis: {
             tickAmount: 5,
             max: 110,


### PR DESCRIPTION
## Summary
- count course views when a course page is displayed
- expose new repository helper to increment view counter
- show top viewed courses on dashboard chart
- adjust area chart to handle category labels

## Testing
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687232b00d3c8333a690ccb410ec654b