### PR TITLE
Enable blog detail page with sidebar and pagination

### DIFF
--- a/app/Http/Controllers/Public/PublicController.php
+++ b/app/Http/Controllers/Public/PublicController.php
@@ -90,8 +90,8 @@ class PublicController extends PublicAbstractController
     public function blogs()
     {
         $data = $this->default_data;
-        $data['blogs']['list'] = BlogRepository::getAll();
-        $data['blogs']['categories'] = BlogCategoryRepository::getAll();
+        $data['blogs']['list'] = BlogRepository::getPublished(100);
+        $data['blogs']['categories'] = BlogCategoryRepository::query()->get();
         return Inertia::render('public/blogs/blogs', [
             'data'  => $data,
         ]);
@@ -99,8 +99,16 @@ class PublicController extends PublicAbstractController
 
     public function blogDetail(string $slug)
     {
-        // Blogs
-        return view('blogs');
+        $data = $this->default_data;
+        $blog = BlogRepository::findBySlug($slug);
+
+        $data['blogs']['single'] = $blog;
+        $data['blogs']['list'] = BlogRepository::getPublished(5);
+        $data['blogs']['categories'] = BlogCategoryRepository::query()->get();
+
+        return Inertia::render('public/blogs/blogDetail', [
+            'data' => $data,
+        ]);
     }
 
     public function careers()

--- a/app/Repositories/BlogRepository.php
+++ b/app/Repositories/BlogRepository.php
@@ -83,5 +83,31 @@ class BlogRepository extends Repository
             'status' => $status,
         ]);
     }
+
+    public static function findBySlug(string $slug): Blog
+    {
+        $blog = self::initQuery()
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        if ($blog->description) {
+            $blog->description = json_decode($blog->description, true);
+        }
+
+        if ($blog->tags) {
+            $blog->tags = json_decode($blog->tags, true);
+        }
+
+        return $blog;
+    }
+
+    public static function getPublished(int $limit = 10)
+    {
+        return self::initQuery()
+            ->where('status', true)
+            ->latest('id')
+            ->take($limit)
+            ->get();
+    }
 }
 

--- a/resources/js/components/blogs/BlogDetail.tsx
+++ b/resources/js/components/blogs/BlogDetail.tsx
@@ -1,0 +1,20 @@
+import { CLASS_NAME } from '@/data/styles/style.constant';
+import { IBlog } from '@/types/blogs';
+
+interface BlogDetailProps {
+    blog: IBlog | null;
+}
+
+export default function BlogDetail({ blog }: BlogDetailProps) {
+    if (!blog) {
+        return <div>Aucun blog trouvé.</div>;
+    }
+
+    return (
+        <article className={`${CLASS_NAME.bgWhite} p-4`}> 
+            <h1 className="text-2xl font-bold mb-4 text-gray-800">{blog.title}</h1>
+            <img src={'https://placehold.co/600x400'} alt={blog.title} className="w-full h-64 object-cover mb-4" />
+            <div className="prose" dangerouslySetInnerHTML={{ __html: blog.description.map((d: any) => `<h3>${d.heading}</h3>${d.body}`).join('') }} />
+        </article>
+    );
+}

--- a/resources/js/pages/public/blogs/blogDetail.tsx
+++ b/resources/js/pages/public/blogs/blogDetail.tsx
@@ -1,5 +1,5 @@
-import BlogGridList from '@/components/blogs/BlogGridList';
 import BlogSidebar from '@/components/blogs/BlogSideBar';
+import BlogDetail from '@/components/blogs/BlogDetail';
 import Hero from '@/components/hero/hearo';
 import { IHeroBreadcrumbItems } from '@/components/hero/HeroCourse';
 import { CLASS_NAME } from '@/data/styles/style.constant';
@@ -8,11 +8,11 @@ import { type SharedData } from '@/types';
 import { IBlog, IBlogCategory } from '@/types/blogs';
 import { Logger } from '@/utils/console.util';
 import { ROUTE_MAP } from '@/utils/route.util';
-import { usePage } from '@inertiajs/react';
+import { router, usePage } from '@inertiajs/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export default function BlogDetail() {
+export default function BlogDetailPage() {
     const { t } = useTranslation();
     const [pageTitle, setPageTitle] = useState(t('PAGES.BLOG_DETAIL', 'Blog Detail'));
     const breadcrumbItems: IHeroBreadcrumbItems[] = [
@@ -20,20 +20,32 @@ export default function BlogDetail() {
         { label: pageTitle, href: '#' },
     ];
 
-    const { auth, data } = usePage<SharedData>().props;
+    const { data } = usePage<SharedData>().props;
 
     const [blog, setBlog] = useState<IBlog | null>(null);
-    // const [blogCategories, setBlogCategories] = useState<IBlogCategory[]>([]);
+    const [recentBlogs, setRecentBlogs] = useState<IBlog[]>([]);
+    const [blogCategories, setBlogCategories] = useState<IBlogCategory[]>([]);
 
     const tags = (): string[] => {
         const allTags: string[] = [];
+        recentBlogs.forEach((b) => {
+            b.tags?.forEach((tag) => {
+                if (!allTags.includes(tag)) {
+                    allTags.push(tag);
+                }
+            });
+        });
         return allTags;
     };
 
     useEffect(() => {
-        if (data.blogs && data.blogs.list) {
-            Logger.log('Blogs data:', data.blogs.list);
+        if (data.blogs) {
             setBlog(data.blogs.single);
+            setRecentBlogs(data.blogs.list ?? []);
+            setBlogCategories(data.blogs.categories ?? []);
+            if (data.blogs.single?.title) {
+                setPageTitle(data.blogs.single.title);
+            }
         }
     }, [data.blogs]);
 
@@ -44,16 +56,21 @@ export default function BlogDetail() {
 
                 <div className={CLASS_NAME.section}>
                     <div className="container">
-                        <div className="grid grid-col-1 md:grid-cols-12">
+                        <div className="grid grid-col-1 md:grid-cols-12 gap-4">
                             <div className="col-span-12 md:col-span-3">
-                                {/* <BlogSidebar
-                                    categories={blogCategories}d
+                                <BlogSidebar
+                                    categories={blogCategories}
                                     tags={tags()}
-                                    recentBlogs={blogs}
-                                    onBlogClick={(blog) => {}}
-                                    onCategorySelect={(category) => {}}
-                                    onTagToggle={(tag) => {}}
-                                /> */}
+                                    recentBlogs={recentBlogs}
+                                    onBlogClick={(id) => {
+                                        const blog = recentBlogs.find((b) => b.id === id);
+                                        if (blog) {
+                                            router.visit(ROUTE_MAP.public.blogs.detail(blog.slug).link);
+                                        }
+                                    }}
+                                    onCategorySelect={() => {}}
+                                    onTagToggle={() => {}}
+                                />
                             </div>
                             <div className="col-span-12 md:col-span-9">
                                 <div className="py-[12px] md:py-[24px]">

--- a/resources/js/pages/public/blogs/blogs.tsx
+++ b/resources/js/pages/public/blogs/blogs.tsx
@@ -3,12 +3,13 @@ import BlogSidebar from '@/components/blogs/BlogSideBar';
 import Hero from '@/components/hero/hearo';
 import { IHeroBreadcrumbItems } from '@/components/hero/HeroCourse';
 import { CLASS_NAME } from '@/data/styles/style.constant';
+import Pagination from '@/components/courses/card/coursePagination';
 import DefaultLayout from '@/layouts/public/front.layout';
 import { type SharedData } from '@/types';
 import { IBlog, IBlogCategory } from '@/types/blogs';
 import { Logger } from '@/utils/console.util';
 import { ROUTE_MAP } from '@/utils/route.util';
-import { usePage } from '@inertiajs/react';
+import { router, usePage } from '@inertiajs/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,41 +21,58 @@ export default function Blogs() {
         { label: pageTitle, href: '#' },
     ];
 
-    const { auth, data } = usePage<SharedData>().props;
+    const { data } = usePage<SharedData>().props;
 
     const [blogs, setBlogs] = useState<IBlog[]>([]);
     const [blogCategories, setBlogCategories] = useState<IBlogCategory[]>([]);
+    const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+    const [selectedTags, setSelectedTags] = useState<string[]>([]);
+    const [currentPage, setCurrentPage] = useState(1);
+    const blogsPerPage = 6;
 
     const tags = (): string[] => {
         const allTags: string[] = [];
-        return allTags;
-        if (blogs && blogs.length > 0) {
-            blogs.forEach((blog: IBlog) => {
-                if (blog.tags && blog.tags.length > 0) {
-                    blog.tags.forEach((tag: string) => {
-                        if (!allTags.includes(tag)) {
-                            allTags.push(tag);
-                        }
-                    });
+        blogs.forEach((blog) => {
+            blog.tags?.forEach((tag) => {
+                if (!allTags.includes(tag)) {
+                    allTags.push(tag);
                 }
             });
-        }
+        });
         return allTags;
     };
 
     useEffect(() => {
         if (data.blogs && data.blogs.list) {
-            Logger.log('Blogs data:', data.blogs.list);
             setBlogs(data.blogs.list);
         }
     }, [data.blogs]);
 
     useEffect(() => {
         if (data.blogs && data.blogs.categories) {
-            Logger.log('Blog categories:', data.blogs.categories);
             setBlogCategories(data.blogs.categories);
         }
     }, [data.blogs]);
+
+    const filteredBlogs = blogs.filter((blog) => {
+        const matchCategory = selectedCategory ? blog.category?.id === selectedCategory : true;
+        const matchTags = selectedTags.length
+            ? selectedTags.every((tag) => blog.tags?.includes(tag))
+            : true;
+        return matchCategory && matchTags;
+    });
+
+    const indexOfLast = currentPage * blogsPerPage;
+    const indexOfFirst = indexOfLast - blogsPerPage;
+    const currentBlogs = filteredBlogs.slice(indexOfFirst, indexOfLast);
+
+    const totalPages = Math.max(Math.ceil(filteredBlogs.length / blogsPerPage), 1);
+
+    const handlePageChange = (page: number) => {
+        if (page < 1 || page > totalPages) return;
+        setCurrentPage(page);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
 
     return (
         <DefaultLayout title={pageTitle} description={pageTitle}>
@@ -63,20 +81,40 @@ export default function Blogs() {
 
                 <div className={CLASS_NAME.section}>
                     <div className="container">
-                        <div className="grid grid-col-1 md:grid-cols-12">
+                        <div className="grid grid-col-1 md:grid-cols-12 gap-4">
                             <div className="col-span-12 md:col-span-4">
                                 <BlogSidebar
                                     categories={blogCategories}
                                     tags={tags()}
                                     recentBlogs={blogs}
-                                    onBlogClick={(blog) => {}}
-                                    onCategorySelect={(category) => {}}
-                                    onTagToggle={(tag) => {}}
+                                    onBlogClick={(id) => {
+                                        const blog = blogs.find((b) => b.id === id);
+                                        if (blog) {
+                                            router.visit(ROUTE_MAP.public.blogs.detail(blog.slug).link);
+                                        }
+                                    }}
+                                    onCategorySelect={(category) => {
+                                        setSelectedCategory(category === selectedCategory ? null : category);
+                                        setCurrentPage(1);
+                                    }}
+                                    onTagToggle={(tag) => {
+                                        setSelectedTags((prev) =>
+                                            prev.includes(tag)
+                                                ? prev.filter((t) => t !== tag)
+                                                : [...prev, tag]
+                                        );
+                                        setCurrentPage(1);
+                                    }}
                                 />
                             </div>
                             <div className="col-span-12 md:col-span-8">
                                 <div className="py-[12px] md:py-[24px]">
-                                    <BlogGridList blogs={blogs} />
+                                    <BlogGridList blogs={currentBlogs} />
+                                    <Pagination
+                                        currentPage={currentPage}
+                                        totalPages={totalPages}
+                                        onPageChange={handlePageChange}
+                                    />
                                 </div>
                             </div>
                         </div>

--- a/routes/front.php
+++ b/routes/front.php
@@ -52,7 +52,7 @@ Route::group(["prefix" => "/"], function () {
      * Blog routes
      */
     Route::get('blogs', [PublicController::class, 'blogs'])->name('blogs');
-    Route::get('blog/{blog_slug}', [PublicController::class, 'blogCategory'])->name('blogs.category');
+    Route::get('blog/{blog_slug}', [PublicController::class, 'blogDetail'])->name('blogs.detail');
 
     /**
      * Careers routes


### PR DESCRIPTION
## Summary
- wire up route for blog detail
- implement repository helpers for blogs
- populate blog detail view with recent posts
- add sidebar functionality
- add pagination to blog list

## Testing
- `composer test` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_6872356856648333a3bbfa1c8c95dc3f