### PR TITLE
Add newsletter submenu links

### DIFF
--- a/resources/js/components/layouts/app/side-bar-item.ts
+++ b/resources/js/components/layouts/app/side-bar-item.ts
@@ -70,6 +70,21 @@ export const MAIN_NAV_ITEMS: NavItem[] = [
         href: route('dashboard.newsletters.index'),
         icon: Mail,
         children: [
+            {
+                title: 'Newsletters',
+                href: route('dashboard.newsletters.index'),
+                icon: List,
+            },
+            {
+                title: 'Templates',
+                href: route('dashboard.newsletter-templates.index'),
+                icon: FileStack,
+            },
+            {
+                title: 'Envoie de mail',
+                href: route('dashboard.newsletters.compose'),
+                icon: ClipboardPlus,
+            },
         ],
     },
     {


### PR DESCRIPTION
## Summary
- add newsletter section children in sidebar to access templates and sending pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: missing sodium extension)*

------
https://chatgpt.com/codex/tasks/task_e_68724ed09a7883338ac18f848fb034fd