### PR TITLE
Fix enrollment seeding

### DIFF
--- a/database/factories/EnrollmentFactory.php
+++ b/database/factories/EnrollmentFactory.php
@@ -2,9 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Repositories\CouponRepository;
-use App\Repositories\CourseRepository;
-use App\Repositories\UserRepository;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EnrollmentFactory extends Factory
@@ -16,12 +13,21 @@ class EnrollmentFactory extends Factory
      */
     public function definition(): array
     {
-        $course = CourseRepository::getAll()->random();
+
+        $courses = \App\Models\Course::has('course_sessions')
+            ->with('course_sessions')
+            ->get();
+
+        if ($courses->isEmpty()) {
+            throw new \Exception('No courses with sessions available');
+        }
+
+        $course = $courses->random();
         $session = $course->course_sessions->random();
        
 
         return [
-            'user_id'                   => UserRepository::getAll()->random()->id,
+            'user_id'                   => \App\Models\User::inRandomOrder()->first()->id,
             'course_id'                 => $course->id,
             'course_session_id'         => $session->id,
             'mode'                      => fake()->randomElement(['online', 'in-person', 'hybrid']), 

--- a/database/seeders/EnrollmentSeeder.php
+++ b/database/seeders/EnrollmentSeeder.php
@@ -13,6 +13,16 @@ class EnrollmentSeeder extends Seeder
      */
     public function run(): void
     {
+        if (\App\Models\Course::has('course_sessions')->count() === 0) {
+            $this->command->warn('Skipping EnrollmentSeeder: no course sessions available.');
+            return;
+        }
+
+        if (\App\Models\User::count() === 0) {
+            $this->command->warn('Skipping EnrollmentSeeder: no users available.');
+            return;
+        }
+
         Enrollment::factory()
             ->count(100)
             ->create();


### PR DESCRIPTION
## Summary
- prevent seeding failures when there are no courses with sessions
- skip EnrollmentSeeder if prerequisites are missing

## Testing
- `composer test` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_6872580dc070833390136c4635ee4c61