### PR TITLE
Fix category select value

### DIFF
--- a/resources/js/components/courses/form/course-basic-info.form.tsx
+++ b/resources/js/components/courses/form/course-basic-info.form.tsx
@@ -107,6 +107,7 @@ export default function CourseBasicInfoForm({ fieldsetClasses, data, setData, pr
                                 selectLabel={t('courses.category', 'Catégorie')}
                                 processing={processing}
                                 onValueChange={(value) => setData('category_id', value)}
+                                defaultValue={data.category_id}
                                 required
                             />
                         )}


### PR DESCRIPTION
## Summary
- keep current course category selected when editing a course

## Testing
- `composer test` *(fails: vendor not installed)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68725873e2008333a6f0f3d4b23dadf2