### PR TITLE
Add Reconversion Metier page and menu link

### DIFF
--- a/app/Http/Controllers/Public/PublicController.php
+++ b/app/Http/Controllers/Public/PublicController.php
@@ -135,6 +135,14 @@ class PublicController extends PublicAbstractController
         ]);
     }
 
+    public function reconversionMetier()
+    {
+        $data = $this->default_data;
+        return Inertia::render('public/reconversion-metier', [
+            'data' => $data,
+        ]);
+    }
+
     public function privacyPolicy()
     {
         return Inertia::render('public/cgu/privacy-policy', [

--- a/resources/js/components/layouts/header/header.tsx
+++ b/resources/js/components/layouts/header/header.tsx
@@ -122,9 +122,9 @@ export default function Header() {
     const PROGRAMMES_DE_RECONVERSION: MenuChildItem = {
         id: 'programmes-de-reconversion',
         label: 'Programmes de reconversion',
-        href: '#',
+        href: ROUTE_MAP.public.reconversionMetier.link,
         description: 'Découvrez nos programmes de reconversion professionnelle.',
-        image: 'assets/images/bg-03.jpg',
+        image: 'https://placehold.jp/150x150.png',
     };
 
     const updateCourseMenuPart = (
@@ -146,7 +146,10 @@ export default function Header() {
                     id: 'formations-children',
                     title: 'Formations',
                     description: 'Liste des formations',
-                    items: buildCategoryItems(data.categories_with_courses),
+                    items: [
+                        PROGRAMMES_DE_RECONVERSION,
+                        ...buildCategoryItems(data.categories_with_courses),
+                    ],
                 },
             };
         });

--- a/resources/js/data/data.constant.ts
+++ b/resources/js/data/data.constant.ts
@@ -23,6 +23,20 @@ export const DEFULAT_MAIN_MENU: IMainMenuItem[] = [
             '',
         gridClass: 'grid-cols-1 lg:grid-cols-3',
         maxWidth: 'w-[900px]',
+        children: {
+            id: 'formations-children',
+            title: 'Formations',
+            description: 'Liste des formations',
+            items: [
+                {
+                    id: 'programmes-de-reconversion',
+                    label: 'Programmes de reconversion',
+                    href: ROUTE_MAP.public.reconversionMetier.link,
+                    description: 'Découvrez nos programmes de reconversion professionnelle.',
+                    image: 'https://placehold.jp/150x150.png',
+                },
+            ],
+        },
     },
     // {
     //     id: 'certifications',

--- a/resources/js/pages/public/reconversion-metier.tsx
+++ b/resources/js/pages/public/reconversion-metier.tsx
@@ -1,0 +1,53 @@
+import Hero, { IHeroBreadcrumbItems } from '@/components/hero/hearo';
+import DefaultLayout from '@/layouts/public/front.layout';
+import { SharedData } from '@/types';
+import { ROUTE_MAP } from '@/utils/route.util';
+import { usePage } from '@inertiajs/react';
+import { useTranslation } from 'react-i18next';
+
+export default function ReconversionMetierPage() {
+    const { auth } = usePage<SharedData>().props;
+    const { t } = useTranslation();
+
+    const breadcrumbItems: IHeroBreadcrumbItems[] = [
+        { label: t('PAGES.HOME', 'Accueil'), href: ROUTE_MAP.public.home.link },
+        { label: 'Reconversion Métier', href: '#' },
+    ];
+
+    return (
+        <DefaultLayout title="Reconversion Métier">
+            <div className="bg-gray-100 dark:bg-[#0a0e19]">
+                <Hero
+                    title="Reconversion Métier"
+                    description="Offres sur-mesure de reconversion « Testeur Logiciel »"
+                    breadcrumbItems={breadcrumbItems}
+                    gradient="style-2"
+                />
+                <div className="container mx-auto px-4 py-8 space-y-4">
+                    <p>
+                        TestPro accompagne les centres de formation, écoles et ESN souhaitant
+                        délivrer des formations de reconversion au métier « Testeur Logiciel »
+                        (POEI, POEC, Programme Région, Rescaling des ressources …).
+                    </p>
+                    <p>
+                        Nos programmes sont animés par des formateurs experts certifiés et
+                        reconnus dans leur domaine, s’appuyant sur notre kit méthodologique de
+                        conduite de projet « QUP » développé à partir de retours d’expériences
+                        et des standards internationaux - ISTQB, IREB, IQBBA, TMAP, TMMi, CMMi,
+                        ISO 25000.
+                    </p>
+                    <img
+                        src="https://placehold.jp/800x400.png"
+                        alt="illustration"
+                        className="mx-auto"
+                    />
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li>Testeur Manuel</li>
+                        <li>Testeur Automatisation</li>
+                        <li>Testeur Full Stack</li>
+                    </ul>
+                </div>
+            </div>
+        </DefaultLayout>
+    );
+}

--- a/resources/js/utils/route.util.ts
+++ b/resources/js/utils/route.util.ts
@@ -36,6 +36,7 @@ interface IROUTE_MAP {
         careers: IRouteMap;
         faqs: IRouteMap;
         contact: IRouteMap;
+        reconversionMetier: IRouteMap;
         privacyPolicy: IRouteMap;
         termsOfService: IRouteMap;
         search: IRouteMap;
@@ -96,6 +97,7 @@ export const ROUTE_MAP: IROUTE_MAP = {
         careers: createIRouteMap(route('careers'), 'Carrières'),
         faqs: createIRouteMap(route('faqs'), 'FAQs'),
         contact: createIRouteMap(route('contact'), 'Nous contacter'),
+        reconversionMetier: createIRouteMap(route('reconversion.metier'), 'Reconversion Métier'),
         privacyPolicy: createIRouteMap(route('privacyPolicy'), 'Politique de confidentialité'),
         termsOfService: createIRouteMap(route('termsOfService'), 'Conditions d’utilisation'),
         search: createIRouteMap(route('search.page'), 'Résultats de recherche'),

--- a/routes/front.php
+++ b/routes/front.php
@@ -30,6 +30,8 @@ Route::group(["prefix" => "/"], function () {
     Route::get('contact', [ContactUsController::class, 'contact'])->name('contact');
     Route::post('contact', [ContactUsController::class, 'contactSubmit'])->name('contact.post');
 
+    Route::get('reconversion-metier', [PublicController::class, 'reconversionMetier'])->name('reconversion.metier');
+
     Route::post('newsletter', [\App\Http\Controllers\Public\NewsletterController::class, 'subscribe'])->name('newsletter.subscribe');
 
     /**


### PR DESCRIPTION
## Summary
- add `reconversion-metier` route and controller method
- create Reconversion Metier page with placeholder image areas
- expose new route in `ROUTE_MAP`
- add Reconversion link to Formation menu

## Testing
- `npm run lint` *(fails: cannot find modules)*
- `npm run types` *(fails: missing type packages)*
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872592621788333a6d2019d4f70009d