### PR TITLE
Add reference tags and seed audit partners

### DIFF
--- a/app/Http/Controllers/Public/PublicController.php
+++ b/app/Http/Controllers/Public/PublicController.php
@@ -9,6 +9,7 @@ use App\Repositories\BlogCategoryRepository;
 use App\Repositories\BlogRepository;
 use App\Repositories\CategoryRepository;
 use App\Repositories\CourseRepository;
+use App\Repositories\ReferenceRepository;
 use App\Repositories\SettingRepository;
 use App\Repositories\SocialMediaRepository;
 use Exception;
@@ -52,8 +53,15 @@ class PublicController extends PublicAbstractController
 
     public function auditMaturity()
     {
+        $data = $this->default_data;
+        $data['references'] = ReferenceRepository::query()
+            ->where('is_active', true)
+            ->where('tag', 'audit-conseil')
+            ->with('media')
+            ->get();
+
         return Inertia::render('public/consulting/consulting-audit', [
-            'data'  => $this->default_data,
+            'data'  => $data,
         ]);
     }
 

--- a/app/Http/Requests/ReferenceStoreRequest.php
+++ b/app/Http/Requests/ReferenceStoreRequest.php
@@ -15,6 +15,7 @@ class ReferenceStoreRequest extends FormRequest
     {
         return [
             'text' => 'nullable|string',
+            'tag' => 'nullable|string',
             'media_id' => 'required|exists:media,id',
         ];
     }

--- a/app/Http/Requests/ReferenceUpdateRequest.php
+++ b/app/Http/Requests/ReferenceUpdateRequest.php
@@ -15,6 +15,7 @@ class ReferenceUpdateRequest extends FormRequest
     {
         return [
             'text' => 'nullable|string',
+            'tag' => 'nullable|string',
             'media_id' => 'nullable|exists:media,id',
         ];
     }

--- a/app/Repositories/ReferenceRepository.php
+++ b/app/Repositories/ReferenceRepository.php
@@ -16,6 +16,7 @@ class ReferenceRepository extends Repository
     {
         return self::create([
             'text' => $request->text,
+            'tag' => $request->tag,
             'media_id' => $request->media_id,
             'is_active' => $request->has('is_active') ? true : false,
         ]);
@@ -25,6 +26,7 @@ class ReferenceRepository extends Repository
     {
         return self::update($reference, [
             'text' => $request->text ?? $reference->text,
+            'tag' => $request->tag ?? $reference->tag,
             'media_id' => $request->media_id ?? $reference->media_id,
             'is_active' => $request->has('is_active') ? true : $reference->is_active,
         ]);

--- a/database/migrations/2025_07_12_041100_add_tag_to_references_table.php
+++ b/database/migrations/2025_07_12_041100_add_tag_to_references_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('references', function (Blueprint $table) {
+            $table->string('tag')->nullable()->after('text');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('references', function (Blueprint $table) {
+            $table->dropColumn('tag');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,6 +36,7 @@ class DatabaseSeeder extends Seeder
 
             TestimonialSeeder::class,
             FaqSeeder::class,
+            ReferenceSeeder::class,
             JobOfferSeeder::class,
         ]);
     }

--- a/database/seeders/ReferenceSeeder.php
+++ b/database/seeders/ReferenceSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enum\MediaTypeEnum;
+use App\Models\Media;
+use App\Models\Reference;
+use Illuminate\Database\Seeder;
+
+class ReferenceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $references = [
+            'CDM - Crédit du Maroc',
+            'Attijariwafa bank',
+            'Crédit Agricole',
+            'BNP Paribas',
+            'HPS',
+            'Deloitte',
+            'inwi',
+            'LabelVie Groupe',
+            'Meti - IT Expertise for Retail',
+            'Compagnie Optorg',
+            'Tractafric Equipment / CAT',
+            'Société Générale',
+            'Wallonie - Service Public SPW',
+            'Smacl Assurances',
+            'CNP Assurances',
+            'Cardif - BNP Paribas Group',
+            'IFP Énergies Nouvelles',
+        ];
+
+        foreach ($references as $text) {
+            $media = Media::factory()->create(['type' => MediaTypeEnum::IMAGE]);
+            Reference::create([
+                'text' => $text,
+                'tag' => 'audit-conseil',
+                'media_id' => $media->id,
+                'is_active' => true,
+            ]);
+        }
+    }
+}

--- a/resources/js/components/references/ReferenceLogos.tsx
+++ b/resources/js/components/references/ReferenceLogos.tsx
@@ -1,0 +1,26 @@
+import { IReference } from '@/types/reference';
+
+interface ReferenceLogosProps {
+    references: IReference[];
+}
+
+export default function ReferenceLogos({ references }: ReferenceLogosProps) {
+    if (!references || references.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="py-8">
+            <div className="container mx-auto flex flex-wrap justify-center gap-6">
+                {references.map((ref) => (
+                    <img
+                        key={ref.id}
+                        src={ref.media?.src}
+                        alt={ref.text ?? ''}
+                        className="h-16 w-auto object-contain"
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/references/referenceDataTable.tsx
+++ b/resources/js/components/references/referenceDataTable.tsx
@@ -51,6 +51,15 @@ export default function ReferenceDataTable({ references, onEditRow, onDeleteRow 
             },
         },
         {
+            accessorKey: 'tag',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Tag
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+        },
+        {
             id: 'actions',
             enableHiding: false,
             cell: ({ row }) => <ReferenceActionBtn row={row} onEdit={onEditRow} onDelete={onDeleteRow} />,

--- a/resources/js/components/references/referenceForm.tsx
+++ b/resources/js/components/references/referenceForm.tsx
@@ -15,6 +15,7 @@ interface ReferenceFormProps {
 
 const defaultValues: IReference = {
     text: '',
+    tag: '',
     is_active: true,
 };
 
@@ -30,6 +31,7 @@ export default function ReferenceForm({ closeDrawer, initialData }: ReferenceFor
             method: initialData?.id ? 'put' : 'post',
             data: {
                 text: data.text,
+                tag: data.tag,
                 media_id: data.media_id,
                 is_active: data.is_active ? '1' : '0',
             },
@@ -49,6 +51,11 @@ export default function ReferenceForm({ closeDrawer, initialData }: ReferenceFor
                 <Label htmlFor="text">{t('Text')}</Label>
                 <Input id="text" value={data.text ?? ''} onChange={(e) => setData('text', e.target.value)} disabled={processing} />
                 <InputError message={errors.text} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="tag">Tag</Label>
+                <Input id="tag" value={data.tag ?? ''} onChange={(e) => setData('tag', e.target.value)} disabled={processing} />
+                <InputError message={errors.tag} />
             </div>
             <div className="grid gap-2">
                 <Label htmlFor="media_id">{t('Media ID')}</Label>

--- a/resources/js/pages/public/consulting/consulting-audit.tsx
+++ b/resources/js/pages/public/consulting/consulting-audit.tsx
@@ -8,6 +8,8 @@ import { type SharedData } from '@/types';
 import { motionVariants } from '@/utils/motion.util';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { Link, usePage } from '@inertiajs/react';
+import ReferenceLogos from '@/components/references/ReferenceLogos';
+import { IReference } from '@/types/reference';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 
@@ -38,6 +40,7 @@ const tests: StaticFeatureItem[] = [
 export default function ConsultingAudit() {
     const { auth, data } = usePage<SharedData>().props;
     const { t } = useTranslation();
+    const references: IReference[] = (data as any)?.references ?? [];
 
     const breadcrumbItems: IHeroBreadcrumbItems[] = [
         { label: t('PAGES.HOME', 'Accueil'), href: ROUTE_MAP.public.home.link },
@@ -177,6 +180,8 @@ export default function ConsultingAudit() {
                 <BlockOne />
 
                 <BlockTwo />
+
+                <ReferenceLogos references={references} />
 
                 <PrevNextPage pages={prevNextPage} />
             </div>

--- a/resources/js/types/reference.d.ts
+++ b/resources/js/types/reference.d.ts
@@ -1,6 +1,7 @@
 export interface IReference {
     id?: number;
     text?: string;
+    tag?: string;
     is_active: boolean;
     media?: IMedia;
     media_id?: number;


### PR DESCRIPTION
## Summary
- add tag column to references table
- allow tag handling in repository and requests
- seed audit & conseil references
- show partners on consulting audit page
- expose tag field in admin forms and tables

## Testing
- `composer install` *(fails: ext-sodium missing)*
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68725a59d26483339d271668002dc742