### PR TITLE
Fix header menu order

### DIFF
--- a/resources/js/components/layouts/header/header.tsx
+++ b/resources/js/components/layouts/header/header.tsx
@@ -147,8 +147,8 @@ export default function Header() {
                     title: 'Formations',
                     description: 'Liste des formations',
                     items: [
-                        PROGRAMMES_DE_RECONVERSION,
                         ...buildCategoryItems(data.categories_with_courses),
+                        PROGRAMMES_DE_RECONVERSION,
                     ],
                 },
             };


### PR DESCRIPTION
## Summary
- ensure PROGRAMMES_DE_RECONVERSION appears after dynamic categories in header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install --no-interaction --ignore-platform-req=ext-sodium` *(fails: could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68725c77669c83338548055b8985630f