### PR TITLE
Display user info in enrollment list

### DIFF
--- a/resources/js/components/enrollments/EnrollmentDataTable.tsx
+++ b/resources/js/components/enrollments/EnrollmentDataTable.tsx
@@ -22,6 +22,26 @@ export default function EnrollmentDataTable({ enrollments, onDeleteRow }: Enroll
             cell: ({ row }) => <span>{row.original.user?.name || '-'}</span>,
         },
         {
+            id: 'email',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Email
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => <span>{row.original.user?.email || '-'}</span>,
+        },
+        {
+            id: 'phone',
+            header: ({ column }) => (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Téléphone
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            ),
+            cell: ({ row }) => <span>{row.original.user?.phone || '-'}</span>,
+        },
+        {
             accessorKey: 'course',
             header: ({ column }) => (
                 <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>


### PR DESCRIPTION
## Summary
- show user email and phone in enrollment table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format:check` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run types`

------
https://chatgpt.com/codex/tasks/task_e_687260e2ff988333b55aaf1be50ac548