### PR TITLE
Add pagination and list view for jobs

### DIFF
--- a/resources/js/components/careers/JobCard.tsx
+++ b/resources/js/components/careers/JobCard.tsx
@@ -2,6 +2,7 @@ import { IJobOffer } from '@/types';
 import { motion, Variants } from 'framer-motion';
 import React, { useState } from 'react';
 import JobApplyModal from './JobApplyModal';
+import { FaMapMarkerAlt } from 'react-icons/fa';
 
 // Composant pour une carte d'offre d'emploi
 export const JobCard: React.FC<{ job: IJobOffer }> = ({ job }) => {
@@ -22,8 +23,13 @@ export const JobCard: React.FC<{ job: IJobOffer }> = ({ job }) => {
             whileHover="hover"
         >
             <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100">{job.title}</h3>
-            <p className="text-gray-600 dark:text-gray-300">
-                {job.company} - {job.location}
+            <p className="text-gray-600 dark:text-gray-300 flex items-center gap-1">
+                {job.company}
+                {job.location && (
+                    <span className="flex items-center gap-1">
+                        - <FaMapMarkerAlt className="inline" /> {job.location}
+                    </span>
+                )}
             </p>
             {job?.salary && (
                 <p className="text-gray-500 dark:text-gray-400">

--- a/resources/js/components/careers/JobList.tsx
+++ b/resources/js/components/careers/JobList.tsx
@@ -1,7 +1,12 @@
 import { IJobOffer } from '@/types';
 import { JobCard } from './JobCard';
+import { JobTable } from './JobTable';
 
-export const JobList: React.FC<{ jobs: IJobOffer[] }> = ({ jobs }) => {
+export const JobList: React.FC<{ jobs: IJobOffer[]; view?: 'card' | 'list' }> = ({ jobs, view = 'card' }) => {
+    if (view === 'list') {
+        return <JobTable jobs={jobs} />;
+    }
+
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {jobs.length > 0 ? (

--- a/resources/js/components/careers/JobPagination.tsx
+++ b/resources/js/components/careers/JobPagination.tsx
@@ -1,0 +1,54 @@
+import { FaAngleLeft, FaAngleRight } from 'react-icons/fa';
+
+interface PaginationProps {
+    currentPage: number;
+    totalPages: number;
+    onPageChange: (page: number) => void;
+}
+
+const JobPagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange }) => {
+    const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+    return (
+        <nav className="mt-10 flex justify-center space-x-2">
+            <button disabled={currentPage === 1} className="rounded px-3 py-1 bg-gray-200" onClick={() => onPageChange(1)}>
+                &laquo;
+            </button>
+            <button
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage === 1}
+                className="rounded px-3 py-1 bg-gray-200 disabled:opacity-50"
+                aria-label="Page précédente"
+            >
+                <FaAngleLeft className="h-4 w-4" />
+            </button>
+            {pageNumbers.map((number) => (
+                <button
+                    key={number}
+                    onClick={() => onPageChange(number)}
+                    className={`cursor-pointer rounded px-3 py-1 ${number === currentPage ? 'bg-primary text-white' : 'bg-gray-200'}`}
+                >
+                    {number}
+                </button>
+            ))}
+            <button
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                className="rounded px-3 py-1 bg-gray-200 disabled:opacity-50"
+                aria-label="Page suivante"
+            >
+                <FaAngleRight className="h-4 w-4" />
+            </button>
+            <button
+                disabled={currentPage === totalPages}
+                onClick={() => onPageChange(totalPages)}
+                className="rounded px-3 py-1 bg-gray-200"
+                aria-label="Dernière page"
+            >
+                &raquo;
+            </button>
+        </nav>
+    );
+};
+
+export default JobPagination;

--- a/resources/js/components/careers/JobTable.tsx
+++ b/resources/js/components/careers/JobTable.tsx
@@ -1,0 +1,50 @@
+import { IJobOffer } from '@/types';
+import { useState } from 'react';
+import JobApplyModal from './JobApplyModal';
+
+export const JobTable: React.FC<{ jobs: IJobOffer[] }> = ({ jobs }) => {
+    const [openJob, setOpenJob] = useState<number | null>(null);
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Titre</th>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Entreprise</th>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Localité</th>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Type</th>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Action</th>
+                    </tr>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    {jobs.length > 0 ? (
+                        jobs.map((job) => (
+                            <tr key={job.id}>
+                                <td className="px-4 py-2 whitespace-nowrap">{job.title}</td>
+                                <td className="px-4 py-2 whitespace-nowrap">{job.company}</td>
+                                <td className="px-4 py-2 whitespace-nowrap">{job.location}</td>
+                                <td className="px-4 py-2 whitespace-nowrap">{job.type}</td>
+                                <td className="px-4 py-2 whitespace-nowrap">
+                                    <button
+                                        onClick={() => setOpenJob(job.id!)}
+                                        className="inline-block rounded bg-primary-600 px-3 py-1 text-white hover:bg-primary-700"
+                                    >
+                                        Postuler
+                                    </button>
+                                    <JobApplyModal jobId={job.id!} open={openJob === job.id} onClose={() => setOpenJob(null)} />
+                                </td>
+                            </tr>
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan={5} className="px-4 py-6 text-center text-gray-600 dark:text-gray-300">
+                                Aucune offre trouvée.
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary
- add pagination component for jobs
- create list-table for job offers
- support list or card view in `JobList`
- enhance job cards with location icon
- integrate pagination and view toggle in careers page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden, registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687265f3b870833380693daddcc5aa8d