### PR TITLE
Improve blog filter UX

### DIFF
--- a/resources/js/components/blogs/BlogSideBar.tsx
+++ b/resources/js/components/blogs/BlogSideBar.tsx
@@ -3,16 +3,18 @@ import { IBlog, IBlogCategory } from '@/types/blogs';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { Link } from '@inertiajs/react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface BlogSidebarProps {
     categories: IBlogCategory[];
     tags: string[];
     recentBlogs: IBlog[];
-    selectedCategory?: number;
+    selectedCategory?: number | null;
     selectedTags?: string[];
     onCategorySelect: (categoryId: number) => void;
     onTagToggle: (tag: string) => void;
     onBlogClick: (blogId: number) => void;
+    onResetFilters: () => void;
 }
 
 const BlogSidebar: React.FC<BlogSidebarProps> = ({
@@ -24,7 +26,11 @@ const BlogSidebar: React.FC<BlogSidebarProps> = ({
     onCategorySelect,
     onTagToggle,
     onBlogClick,
-}) => (
+    onResetFilters,
+}) => {
+    const { t } = useTranslation();
+
+    return (
     <div className="w-full">
         {/* Blogs récents */}
         <div className={`${CLASS_NAME.bgWhite} m-4 p-2`}>
@@ -46,13 +52,23 @@ const BlogSidebar: React.FC<BlogSidebarProps> = ({
 
         {/* Catégories */}
         <div className={`${CLASS_NAME.bgWhite} m-4 p-2`}>
-            <h3 className="text-lg font-semibold mb-3 text-gray-800">Catégories</h3>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-semibold text-gray-800">Catégories</h3>
+                <button
+                    onClick={onResetFilters}
+                    className="text-sm text-primary hover:underline"
+                >
+                    {t('FILTER.RESET', 'Réinitialiser')}
+                </button>
+            </div>
             <ul className="space-y-2">
                 {categories.map((cat) => (
                     <li key={cat.id}>
                         <button
-                            className={`w-full text-left px-3 py-2 rounded transition ${
-                                selectedCategory === cat.id ? 'bg-blue-100 text-blue-700 font-bold' : 'hover:bg-gray-100 text-gray-700'
+                            className={`w-full text-left px-3 py-2 rounded transition border ${
+                                selectedCategory === cat.id
+                                    ? 'border-primary bg-blue-100 text-blue-700 font-bold'
+                                    : 'border-transparent hover:bg-gray-100 text-gray-700 hover:border-gray-200'
                             }`}
                             onClick={() => onCategorySelect(cat.id)}
                         >
@@ -72,8 +88,8 @@ const BlogSidebar: React.FC<BlogSidebarProps> = ({
                         key={tag}
                         className={`px-3 py-1 rounded-full text-xs border transition ${
                             selectedTags.includes(tag)
-                                ? 'bg-blue-600 text-white border-blue-600'
-                                : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-blue-100 hover:text-blue-700'
+                                ? 'border-primary bg-blue-600 text-white'
+                                : 'border-gray-200 bg-gray-100 text-gray-700 hover:bg-blue-100 hover:text-blue-700'
                         }`}
                         onClick={() => onTagToggle(tag)}
                     >
@@ -83,6 +99,7 @@ const BlogSidebar: React.FC<BlogSidebarProps> = ({
             </div>
         </div>
     </div>
-);
+    );
+};
 
 export default BlogSidebar;

--- a/resources/js/pages/public/blogs/blogs.tsx
+++ b/resources/js/pages/public/blogs/blogs.tsx
@@ -89,6 +89,8 @@ export default function Blogs() {
                                     categories={blogCategories}
                                     tags={tags()}
                                     recentBlogs={blogs}
+                                    selectedCategory={selectedCategory}
+                                    selectedTags={selectedTags}
                                     onBlogClick={(id) => {
                                         const blog = blogs.find((b) => b.id === id);
                                         if (blog) {
@@ -101,6 +103,11 @@ export default function Blogs() {
                                     }}
                                     onTagToggle={(tag) => {
                                         setSelectedTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+                                        setCurrentPage(1);
+                                    }}
+                                    onResetFilters={() => {
+                                        setSelectedCategory(null);
+                                        setSelectedTags([]);
                                         setCurrentPage(1);
                                     }}
                                 />


### PR DESCRIPTION
## Summary
- add category/tag state props and reset control to BlogSidebar
- show active filter border
- expose filters to sidebar on blogs page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: error TS1005 in HeaderNavTwoMobile.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6879bae1cff88333a949a45feb76bad3