### PR TITLE
Adapt job application flow

### DIFF
--- a/app/Http/Requests/JobApplicationStoreRequest.php
+++ b/app/Http/Requests/JobApplicationStoreRequest.php
@@ -16,8 +16,7 @@ class JobApplicationStoreRequest extends FormRequest
         return [
             'job_offer_id' => 'required|exists:job_offers,id',
             'name' => 'required|string',
-            'email' => 'required|email',
-            'message' => 'nullable|string',
+            'cv' => 'required|file|mimes:pdf,doc,docx|max:2048',
         ];
     }
 }

--- a/app/Mail/JobApplicationMail.php
+++ b/app/Mail/JobApplicationMail.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Http\UploadedFile;
+
+class JobApplicationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public string $name,
+        public int $jobOfferId,
+        public UploadedFile $cv
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Nouvelle candidature',
+            from: new Address(config('mail.from.address'), config('app.name')),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.job-application.mail',
+            with: [
+                'name' => $this->name,
+                'job_offer_id' => $this->jobOfferId,
+            ]
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [
+            Attachment::fromPath(
+                $this->cv->getRealPath()
+            )
+                ->as($this->cv->getClientOriginalName())
+                ->withMime($this->cv->getClientMimeType()),
+        ];
+    }
+}

--- a/resources/js/components/careers/JobApplyModal.tsx
+++ b/resources/js/components/careers/JobApplyModal.tsx
@@ -1,6 +1,7 @@
 import { IJobApplication } from '@/types';
 import { router } from '@inertiajs/react';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import BtnSecondary from '../ui/button/btn-secondary';
 import { Button } from '../ui/button/button';
 
@@ -14,8 +15,7 @@ export default function JobApplyModal({ jobId, open, onClose }: Props) {
     const [form, setForm] = useState<IJobApplication>({
         job_offer_id: jobId,
         name: '',
-        email: '',
-        message: '',
+        cv: null,
     });
 
     if (!open) return null;
@@ -26,7 +26,14 @@ export default function JobApplyModal({ jobId, open, onClose }: Props) {
                 onSubmit={(e) => {
                     e.preventDefault();
                     router.post(route('job.apply'), form, {
-                        onSuccess: onClose,
+                        forceFormData: true,
+                        onSuccess: () => {
+                            toast.success('Candidature envoyée');
+                            onClose();
+                        },
+                        onError: () => {
+                            toast.error("Erreur lors de l'envoi");
+                        },
                     });
                 }}
                 className="space-y-4 rounded bg-white p-6"
@@ -40,18 +47,10 @@ export default function JobApplyModal({ jobId, open, onClose }: Props) {
                     required
                 />
                 <input
+                    type="file"
                     className="w-full rounded border p-2"
-                    placeholder="Email"
-                    type="email"
-                    value={form.email}
-                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    onChange={(e) => setForm({ ...form, cv: e.target.files ? e.target.files[0] : null })}
                     required
-                />
-                <textarea
-                    className="w-full rounded border p-2"
-                    placeholder="Message"
-                    value={form.message}
-                    onChange={(e) => setForm({ ...form, message: e.target.value })}
                 />
                 <div className="flex justify-end gap-2">
                     <Button type="button" onClick={onClose} className="rounded bg-red-300 hover:bg-red-400">

--- a/resources/js/types/job-offer.d.ts
+++ b/resources/js/types/job-offer.d.ts
@@ -14,6 +14,5 @@ export interface IJobOffer {
 export interface IJobApplication {
     job_offer_id: number;
     name: string;
-    email: string;
-    message?: string;
+    cv: File | null;
 }

--- a/resources/views/mail/job-application/mail.blade.php
+++ b/resources/views/mail/job-application/mail.blade.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+<html lang="fr">
+
+<head>
+
+    <meta charset="UTF-8">
+
+    <title>Nouvelle candidature</title>
+
+</head>
+
+<body>
+
+    <h1>Nouvelle candidature</h1>
+
+    <p>Nom complet : {{ $name }}</p>
+
+    <p>ID de l'offre : {{ $job_offer_id }}</p>
+
+    <p>Le CV est joint à ce message.</p>
+
+</body>
+
+</html>
+


### PR DESCRIPTION
## Summary
- add `JobApplicationMail` mailable with attachment
- update request validation for CV upload
- send job applications by email instead of storing
- simplify `JobApplyModal` to only request name and CV
- update TS types for new form
- add mail view for applications

## Testing
- `npm run lint` *(fails: cannot find packages)*
- `composer test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_6879ba7ea4248333a118bb1250293114