### PR TITLE
Fix blog detail description

### DIFF
--- a/app/Repositories/BlogRepository.php
+++ b/app/Repositories/BlogRepository.php
@@ -91,7 +91,10 @@ class BlogRepository extends Repository
             ->firstOrFail();
 
         if ($blog->description) {
-            $blog->description = json_decode($blog->description, true);
+            $decoded = json_decode($blog->description, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $blog->description = $decoded;
+            }
         }
 
         if ($blog->tags) {


### PR DESCRIPTION
## Summary
- display blog description correctly when stored as HTML

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879bc0639948333acbabdf5d9782aba