### PR TITLE
Fix course listing in category page

### DIFF
--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -139,7 +139,22 @@ class CategoryRepository extends Repository
 
         // Si un categoryId est fourni, retourner l'arbre à partir de cette catégorie
         if ($categoryId !== null) {
-            return isset($categoriesByParent[$categoryId]) ? $buildTree($categoryId) : [];
+            $rootCategory = $categories->firstWhere('id', $categoryId);
+            $childrenTree = isset($categoriesByParent[$categoryId]) ? $buildTree($categoryId) : [];
+
+            if ($rootCategory) {
+                $rootNode = $rootCategory->toArray();
+                $rootNode['image'] = [
+                    'id' => $rootCategory->image?->id,
+                    'src' => $rootCategory->imagePath,
+                ];
+                $rootNode['children'] = $childrenTree;
+                $rootNode['courses'] = $includeCourses ? CourseRepository::findAllByCategoryId($rootCategory->id) : [];
+
+                return [$rootNode];
+            }
+
+            return $childrenTree;
         }
 
         // Sinon, retourner l'arbre complet à partir de la racine (parent_id = 0)


### PR DESCRIPTION
## Summary
- ensure `getRecursiveTree` includes the root category when loading a specific category

## Testing
- `composer test` *(fails: vendor autoload not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879c16e1b9c8333bc86be712bbdc518