### PR TITLE
Enable parent category selection

### DIFF
--- a/app/Http/Requests/CategoryUpdateRequest.php
+++ b/app/Http/Requests/CategoryUpdateRequest.php
@@ -25,6 +25,7 @@ class CategoryUpdateRequest extends FormRequest
             'title' => 'string|max:50',
             // 'color' => 'string|min:7|max:7',
             'media' => "image|mimes:jpeg,png,jpg|max:2048",
+            'parent_id' => 'nullable|exists:categories,id',
             'is_featured' => '',
         ];
     }

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -7,6 +7,7 @@ use App\Enum\MediaTypeEnum;
 use App\Http\Requests\CategoryStoreRequest;
 use App\Http\Requests\CategoryUpdateRequest;
 use App\Models\Category;
+use Illuminate\Support\Str;
 
 class CategoryRepository extends Repository
 {
@@ -208,9 +209,11 @@ class CategoryRepository extends Repository
 
         return self::create([
             'title'       => $request->title,
+            'slug'        => Str::slug($request->title),
             'media_id'    => $media ? $media->id : null,
+            'parent_id'   => $request->parent_id,
             'is_featured' => $isFeatured,
-            'color'       => $request->color
+            'color'       => $request->color,
         ]);
     }
 
@@ -245,10 +248,12 @@ class CategoryRepository extends Repository
         }
 
         return self::update($category, [
-            'title' => $request->title ?? $category->title,
-            'media_id' => $media ? $media->id : null,
+            'title'       => $request->title ?? $category->title,
+            'slug'        => $request->title ? Str::slug($request->title) : $category->slug,
+            'media_id'    => $media ? $media->id : null,
+            'parent_id'   => $request->parent_id ?? $category->parent_id,
             'is_featured' => $isFeatured,
-            'color' => $request->color ?? $category->color
+            'color'       => $request->color ?? $category->color,
         ]);
     }
 }

--- a/resources/js/components/courses/categories/categoryForm.tsx
+++ b/resources/js/components/courses/categories/categoryForm.tsx
@@ -90,6 +90,9 @@ function CategoryForm({ closeDrawer, initialData }: CategoryFormProps) {
         const formData = new FormData();
         formData.append('title', data.title);
         formData.append('is_featured', data.is_featured ? '1' : '0');
+        if (data.parent_id) {
+            formData.append('parent_id', data.parent_id.toString());
+        }
         if (file) {
             formData.append('media', file);
         }
@@ -99,6 +102,7 @@ function CategoryForm({ closeDrawer, initialData }: CategoryFormProps) {
             data: {
                 title: data.title,
                 is_featured: data.is_featured ? '1' : '0',
+                parent_id: data.parent_id,
                 ...(file && { media: file }),
             },
             forceFormData: true, // Important pour envoyer des fichiers
@@ -149,6 +153,7 @@ function CategoryForm({ closeDrawer, initialData }: CategoryFormProps) {
                     selectLabel={t('courses.category', 'Catégorie')}
                     processing={processing}
                     onValueChange={(value) => setData('parent_id', value)}
+                    defaultValue={data.parent_id?.toString()}
                     required
                 />
                 <InputError message={errors.parent_id} />


### PR DESCRIPTION
## Summary
- allow picking parent category
- save slug and parent id for categories
- support parent_id field in update request

## Testing
- `composer test` *(fails: failed to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a279f6424833383ca8122417be70d