### PR TITLE
Fix course update

### DIFF
--- a/resources/js/components/courses/form/course-additionnal.form.tsx
+++ b/resources/js/components/courses/form/course-additionnal.form.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import TooltipCustom from '@/components/ui/TooltipCustom';
 import { Info } from 'lucide-react';
-import { lazy, useState } from 'react';
+import { lazy, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import 'react-quill/dist/quill.snow.css';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '../../ui/select';
@@ -25,6 +25,10 @@ interface CourseAdditionnalFormProps {
 
 export default function CourseAdditionnalForm({ fieldsetClasses, data, setData, processing, errors }: CourseAdditionnalFormProps) {
     const [displayPrice, setDisplayPrice] = useState<string>(() => (data.price ? Number(data.price).toLocaleString('fr-FR') : ''));
+
+    useEffect(() => {
+        setDisplayPrice(data.price ? Number(data.price).toLocaleString('fr-FR') : '');
+    }, [data.price]);
     const { t } = useTranslation();
 
     return (

--- a/resources/js/components/courses/form/course-basic-info.form.tsx
+++ b/resources/js/components/courses/form/course-basic-info.form.tsx
@@ -107,7 +107,7 @@ export default function CourseBasicInfoForm({ fieldsetClasses, data, setData, pr
                                 selectLabel={t('courses.category', 'Catégorie')}
                                 processing={processing}
                                 onValueChange={(value) => setData('category_id', value)}
-                                defaultValue={data.category_id}
+                                value={data.category_id}
                                 required
                             />
                         )}

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -134,9 +134,13 @@ function CourseForm({ course }: ICourseFormProps) {
         if (data?.id) formData.append('_method', 'PUT');
 
         try {
-            const response = await axios.post(route(routeName, data?.id), formData, {
-                headers: { 'Content-Type': 'multipart/form-data' },
-            });
+            const response = await axios.post(
+                data?.id ? route(routeName, course?.slug) : route(routeName),
+                formData,
+                {
+                    headers: { 'Content-Type': 'multipart/form-data' },
+                },
+            );
             console.log('Course creation response:', response);
 
             // toast.success(t('courses.createSuccess', 'Formation créée avec succès !'));

--- a/resources/js/components/ui/select-custom.tsx
+++ b/resources/js/components/ui/select-custom.tsx
@@ -22,6 +22,7 @@ interface SelectCustomProps {
   required?: boolean;
   disabled?: boolean;
   defaultValue?: string;
+  value?: string;
   onValueChange: (value: string) => void;
   processing: boolean;
   data: ISelectItem[];
@@ -36,13 +37,14 @@ export default function SelectCustom({
   data,
   selectLabel,
   defaultValue,
+  value,
   groupLabel,
 }: SelectCustomProps) {
   return (
     <Select
       disabled={processing}
       required={required}
-      value={defaultValue}
+      value={value ?? defaultValue}
       onValueChange={onValueChange}
     >
       <SelectTrigger className="w-full">


### PR DESCRIPTION
## Summary
- fix update route for course editing
- refresh price display when data changes
- ensure category selection keeps current value
- support controlled value in `SelectCustom`

## Testing
- `composer test` *(fails: vendor autoload not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a28e9d62483339efb9ae98c3bcb1c