### PR TITLE
Add course session creation drawer

### DIFF
--- a/app/Http/Controllers/Private/CourseSessionController.php
+++ b/app/Http/Controllers/Private/CourseSessionController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Private;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CourseSessionBatchStoreRequest;
+use App\Repositories\CourseSessionRepository;
+use Illuminate\Http\JsonResponse;
+
+class CourseSessionController extends Controller
+{
+    public function store(CourseSessionBatchStoreRequest $request): JsonResponse
+    {
+        $created = [];
+        foreach ($request->validated('sessions') as $sessionData) {
+            $created[] = CourseSessionRepository::create([
+                'course_id' => $request->validated('course_id'),
+                'location' => $sessionData['location'] ?? null,
+                'country' => $sessionData['country'] ?? null,
+                'city' => $sessionData['city'] ?? null,
+                'longitude' => $sessionData['longitude'] ?? null,
+                'latitude' => $sessionData['latitude'] ?? null,
+                'timezone' => $sessionData['timezone'] ?? null,
+                'language' => $sessionData['language'] ?? null,
+                'start_date' => $sessionData['start_date'],
+                'end_date' => $sessionData['end_date'] ?? null,
+                'price' => $sessionData['price'] ?? 0,
+                'price_discount' => $sessionData['price_discount'] ?? 0,
+                'tva' => $sessionData['tva'] ?? 0,
+            ]);
+        }
+
+        return response()->json(['sessions' => $created], 201);
+    }
+}

--- a/app/Http/Requests/CourseSessionBatchStoreRequest.php
+++ b/app/Http/Requests/CourseSessionBatchStoreRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CourseSessionBatchStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'course_id' => 'required|exists:courses,id',
+            'sessions' => 'required|array|min:1',
+            'sessions.*.start_date' => 'required|date',
+            'sessions.*.end_date' => 'nullable|date|after_or_equal:sessions.*.start_date',
+            'sessions.*.location' => 'nullable|string',
+            'sessions.*.price' => 'nullable|numeric',
+            'sessions.*.price_discount' => 'nullable|numeric',
+            'sessions.*.tva' => 'nullable|numeric',
+        ];
+    }
+}

--- a/resources/js/components/courses/card/courseCard.tsx
+++ b/resources/js/components/courses/card/courseCard.tsx
@@ -2,7 +2,9 @@ import { SharedData } from '@/types';
 import { ICourse } from '@/types/course';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { Link, usePage } from '@inertiajs/react';
-import { Edit2Icon, Trash2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { Edit2Icon, Trash2Icon, CirclePlus } from 'lucide-react';
+import CourseSessionCreateDrawer from '../session/CourseSessionCreateDrawer';
 import { FaClock, FaMapMarkerAlt } from 'react-icons/fa'; // Import icons
 import './CourseCard.css'; // Link to CSS file
 
@@ -13,6 +15,7 @@ interface CourseCardProps {
 
 const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete }) => {
     const { auth } = usePage<SharedData>().props;
+    const [openSessionDrawer, setOpenSessionDrawer] = useState(false);
 
     const CourseHeader = () => {
         return (
@@ -80,6 +83,15 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete }) => {
                     </div>
 
                     <div className="flex gap-x-2">
+                        {auth?.user?.is_admin && (
+                            <button
+                                onClick={() => setOpenSessionDrawer(true)}
+                                className="text-blue-500 p-4 rounded-full hover:bg-blue-400 hover:text-white"
+                                type="button"
+                            >
+                                <CirclePlus className="w-4 h-4" />
+                            </button>
+                        )}
                         <Link
                             href={ROUTE_MAP.dashboard.course.edit(course.slug).link}
                             className="text-green-400 p-4 rounded-full hover:bg-green-400 hover:text-white"
@@ -134,6 +146,11 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete }) => {
                 <CourseDuration />
                 <CourseFooter />
             </div>
+            <CourseSessionCreateDrawer
+                open={openSessionDrawer}
+                setOpen={setOpenSessionDrawer}
+                courseId={course.id}
+            />
         </div>
     );
 };

--- a/resources/js/components/courses/session/CourseSessionCreateDrawer.tsx
+++ b/resources/js/components/courses/session/CourseSessionCreateDrawer.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import axios from 'axios';
+import Drawer from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button/button';
+import { Input } from '@/components/ui/input';
+import { Logger } from '@/utils/console.util';
+
+interface CourseSessionCreateDrawerProps {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    courseId: number;
+}
+
+interface SessionForm {
+    start_date: string;
+    end_date: string;
+}
+
+const emptySession: SessionForm = { start_date: '', end_date: '' };
+
+export default function CourseSessionCreateDrawer({ open, setOpen, courseId }: CourseSessionCreateDrawerProps) {
+    const { t } = useTranslation();
+    const [sessions, setSessions] = useState<SessionForm[]>([{ ...emptySession }]);
+    const [loading, setLoading] = useState(false);
+
+    const handleAdd = () => setSessions([...sessions, { ...emptySession }]);
+    const handleRemove = (idx: number) => {
+        const copy = [...sessions];
+        copy.splice(idx, 1);
+        setSessions(copy.length ? copy : [{ ...emptySession }]);
+    };
+    const handleChange = (idx: number, field: keyof SessionForm, value: string) => {
+        const copy = [...sessions];
+        copy[idx][field] = value;
+        setSessions(copy);
+    };
+
+    const handleSubmit = () => {
+        setLoading(true);
+        axios
+            .post(route('dashboard.course.session.store'), { course_id: courseId, sessions })
+            .then(() => {
+                setOpen(false);
+                setSessions([{ ...emptySession }]);
+            })
+            .catch((e) => Logger.error('create sessions', e))
+            .finally(() => setLoading(false));
+    };
+
+    return (
+        <Drawer
+            title={t('course.session.create', 'Créer des sessions')}
+            open={open}
+            setOpen={setOpen}
+            component={
+                <div className="space-y-4">
+                    {sessions.map((session, index) => (
+                        <div key={index} className="space-y-2 border-b pb-4">
+                            <div className="grid grid-cols-2 gap-2">
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        {t('start_date', 'Date de début')}
+                                    </label>
+                                    <Input
+                                        type="datetime-local"
+                                        value={session.start_date}
+                                        onChange={(e) => handleChange(index, 'start_date', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        {t('end_date', 'Date de fin')}
+                                    </label>
+                                    <Input
+                                        type="datetime-local"
+                                        value={session.end_date}
+                                        onChange={(e) => handleChange(index, 'end_date', e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                            {sessions.length > 1 && (
+                                <Button
+                                    variant="outline"
+                                    type="button"
+                                    className="text-red-500"
+                                    onClick={() => handleRemove(index)}
+                                >
+                                    {t('remove', 'Retirer')}
+                                </Button>
+                            )}
+                        </div>
+                    ))}
+                    <div className="flex justify-between">
+                        <Button variant="outline" type="button" onClick={handleAdd}>
+                            {t('course.session.add', 'Ajouter une session')}
+                        </Button>
+                        <Button type="button" onClick={handleSubmit} disabled={loading}>
+                            {loading ? t('creating', 'Création...') : t('course.session.save', 'Enregistrer')}
+                        </Button>
+                    </div>
+                </div>
+            }
+        />
+    );
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Private\BlogCategoryController;
 use App\Http\Controllers\Private\BlogController;
 use App\Http\Controllers\Private\CategoryController;
 use App\Http\Controllers\Private\CourseController;
+use App\Http\Controllers\Private\CourseSessionController;
 use App\Http\Controllers\Private\DashboardController;
 use App\Http\Controllers\Private\FaqController;
 use App\Http\Controllers\Private\NewsletterController;
@@ -46,6 +47,7 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::post('create',           [CourseController::class, 'store'])->name('dashboard.course.store');
         Route::put('update/{slug}',     [CourseController::class, 'update'])->name('dashboard.course.update');
         Route::delete('delete/{id}',    [CourseController::class, 'delete'])->name('dashboard.course.delete');
+        Route::post('{course}/sessions', [CourseSessionController::class, 'store'])->name('dashboard.course.session.store');
     });
 
     // CATEGORY COURSE MANAGEMENT


### PR DESCRIPTION
## Summary
- add controller and request for batch session creation
- expose a dashboard route to create sessions
- provide UI drawer to add multiple sessions per course
- link drawer from course cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a29ae78a88333b1f2ef9488952947