### PR TITLE
Fix missing route param

### DIFF
--- a/resources/js/components/courses/session/CourseSessionCreateDrawer.tsx
+++ b/resources/js/components/courses/session/CourseSessionCreateDrawer.tsx
@@ -61,7 +61,7 @@ export default function CourseSessionCreateDrawer({ open, setOpen, courseId }: C
     const handleSubmit = () => {
         setLoading(true);
         axios
-            .post(route('dashboard.course.session.store'), { course_id: courseId, sessions })
+            .post(route('dashboard.course.session.store', { course: courseId }), { course_id: courseId, sessions })
             .then(() => {
                 setOpen(false);
                 setSessions([{ ...emptySession }]);


### PR DESCRIPTION
## Summary
- include `course` parameter when calling dashboard.course.session.store

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a31de52dc8333adadd76573be0644