### PR TITLE
Handle course form errors and show required marks

### DIFF
--- a/resources/js/components/courses/form/course-additionnal.form.tsx
+++ b/resources/js/components/courses/form/course-additionnal.form.tsx
@@ -55,7 +55,9 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, setData, 
                 </div>
 
                 <div className="grid gap-2">
-                    <Label htmlFor="price">{t('courses.price', 'Prix')} (FCFA) </Label>
+                    <Label htmlFor="price">
+                        {t('courses.price', 'Prix')} (FCFA) <span className="text-red-500">*</span>
+                    </Label>
                     <Input
                         id="price"
                         type="text"
@@ -88,7 +90,9 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, setData, 
                 </div>
 
                 <div className="grid gap-2">
-                    <Label htmlFor="duration">{t('courses.duration', 'Durée')}</Label>
+                    <Label htmlFor="duration">
+                        {t('courses.duration', 'Durée')} <span className="text-red-500">*</span>
+                    </Label>
                     <Input
                         id="duration"
                         type="number"
@@ -101,7 +105,9 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, setData, 
                 </div>
 
                 <div className="grid gap-2">
-                    <Label htmlFor="periodicity_unit">{t('courses.periodicity_unit', 'Periodicité')}</Label>
+                    <Label htmlFor="periodicity_unit">
+                        {t('courses.periodicity_unit', 'Periodicité')} <span className="text-red-500">*</span>
+                    </Label>
                     <Select disabled={processing} value={data.periodicity_unit} onValueChange={(value) => setData('periodicity_unit', value)}>
                         <SelectTrigger className="w-full">
                             <SelectValue placeholder="Sélectionner une catégorie" />

--- a/resources/js/components/courses/form/course-basic-info.form.tsx
+++ b/resources/js/components/courses/form/course-basic-info.form.tsx
@@ -76,7 +76,9 @@ export default function CourseBasicInfoForm({
                 <legend className="px-2 text-base font-semibold">{t('courses.mainInfo', 'Informations principales')}</legend>
                 <div className="grid gap-4">
                     <div className="grid gap-2">
-                        <Label htmlFor="title">{t('courses.title', 'Titre')}</Label>
+                        <Label htmlFor="title">
+                            {t('courses.title', 'Titre')} <span className="text-red-500">*</span>
+                        </Label>
                         <Input
                             id="title"
                             type="text"
@@ -91,7 +93,9 @@ export default function CourseBasicInfoForm({
                     </div>
 
                     <div className="grid gap-2">
-                        <Label htmlFor="excerpt">{t('courses.excerpt', 'Extrait')}</Label>
+                        <Label htmlFor="excerpt">
+                            {t('courses.excerpt', 'Extrait')} <span className="text-red-500">*</span>
+                        </Label>
                         <Textarea
                             id="excerpt"
                             required
@@ -111,7 +115,9 @@ export default function CourseBasicInfoForm({
                 <legend className="px-2 text-base font-semibold">{t('courses.category', 'Catégorie')}</legend>
                 <div className="grid gap-4">
                     <div className="grid gap-2">
-                        {/* <Label htmlFor="title">{t('courses.category', 'Catégorie')}</Label> */}
+                        <Label htmlFor="category_id">
+                            {t('courses.category', 'Catégorie')} <span className="text-red-500">*</span>
+                        </Label>
 
                         {categories && categories.length > 0 && (
                             <SelectCustom

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -1,5 +1,6 @@
 import { router, useForm, usePage } from '@inertiajs/react';
 import { InfoIcon, LoaderCircle, LoaderIcon } from 'lucide-react';
+import { handleErrorsRequest } from '@/utils/utils';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -152,8 +153,10 @@ function CourseForm({ course }: ICourseFormProps) {
      * @returns {Promise<void>}
      */
     const submit = async (data: ICourseForm, draft: boolean = false): Promise<void> => {
-        validationBeformSubmitForm();
-        if (Object.keys(setErrors).length > 0) {
+        setLoading(true);
+        const isValid = validationBeformSubmitForm();
+        if (!isValid) {
+            setLoading(false);
             return;
         }
         const routeName = data?.id ? 'dashboard.course.update' : 'dashboard.course.store';
@@ -182,8 +185,9 @@ function CourseForm({ course }: ICourseFormProps) {
             // toast.success(t('courses.createSuccess', 'Formation créée avec succès !'));
             // return router.visit(ROUTE_MAP.dashboard.course.list.link);
         } catch (error: any) {
-            toast.error(t('courses.createError', 'Erreur lors de la création de la formation'));
-            console.error('Course creation error:', error);
+            handleErrorsRequest(error, setLoading, (message) => toast.error(message), setErrors);
+        } finally {
+            setLoading(false);
         }
     };
 
@@ -390,6 +394,9 @@ function CourseForm({ course }: ICourseFormProps) {
                         </div>
                     </div>
                 </div>
+                <p className="text-sm text-gray-500 mt-4">
+                    Les champs marqués d'un <span className="text-red-500">*</span> sont obligatoires.
+                </p>
             </form>
 
             <Drawer


### PR DESCRIPTION
## Summary
- display red asterisk for course form required fields
- report API validation errors using `handleErrorsRequest`
- show note about required fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a37d726508333bade694707d18c9b