### PR TITLE
Add course reference tag

### DIFF
--- a/app/Http/Controllers/Public/PublicFormationController.php
+++ b/app/Http/Controllers/Public/PublicFormationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\PublicAbstractController;
 use App\Repositories\CategoryRepository;
 use App\Repositories\CourseRepository;
 use App\Repositories\CourseSessionRepository;
+use App\Repositories\PartnerRepository;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
@@ -143,6 +144,14 @@ class PublicFormationController extends PublicAbstractController
 
             $data['category'] = $category;
             $data['course'] = $course;
+            $data['references'] = PartnerRepository::query()
+                ->where('is_active', true)
+                ->where('is_reference', true)
+                ->when($course->reference_tag, function ($query) use ($course) {
+                    $query->where('tag', $course->reference_tag);
+                })
+                ->with('media')
+                ->get();
 
             return Inertia::render('public/courses/course-detail.page', [
                 'data' => $data,

--- a/app/Http/Requests/CourseStoreRequest.php
+++ b/app/Http/Requests/CourseStoreRequest.php
@@ -36,6 +36,7 @@ class CourseStoreRequest extends FormRequest
             'partner_ids'           => 'sometimes|array',
             'partner_ids.*'         => 'exists:partners,id',
             'regular_price'         => 'numeric|min:' . ((float) config('app.minimum_amount')),
+            'reference_tag'         => 'nullable|string',
             'price' => [
                 'nullable',
                 'numeric',

--- a/app/Http/Requests/CourseUpdateRequest.php
+++ b/app/Http/Requests/CourseUpdateRequest.php
@@ -37,6 +37,7 @@ class CourseUpdateRequest extends FormRequest
             'regular_price'         => 'required|numeric|min:' . ((float) config('app.minimum_amount')),
             'instructor_id'         => 'exists:instructors,id',
             'is_active'             => 'nullable',
+            'reference_tag'         => 'nullable|string',
             'price' => [
                 'nullable',
                 'numeric',

--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -251,6 +251,7 @@ class CourseRepository extends Repository
             'logo_id'       => $logo ? $logo->id : null,
             'organization_logo_id' => $organizationLogo ? $organizationLogo->id : null,
             'video_id'      => $video ? $video->id : null,
+            'reference_tag' => $request->reference_tag,
             'description'   => $request->description ?? "", // json_encode($request->description)
             'regular_price' => $request->regular_price,
             'price'         => $request->price,
@@ -382,6 +383,7 @@ class CourseRepository extends Repository
             'logo_id'       => $logo ? $logo->id : $course->logo_id,
             'organization_logo_id' => $organizationLogo ? $organizationLogo->id : $course->organization_logo_id,
             'video_id'      => $video ? $video->id : null,
+            'reference_tag' => $request->reference_tag ?? $course->reference_tag,
             'description'   => json_encode($request->description) ?? $course->description,
             'regular_price' => $request->regular_price ?? null,
             'price'         => $request->price,

--- a/database/migrations/2025_07_12_062100_add_reference_tag_to_courses_table.php
+++ b/database/migrations/2025_07_12_062100_add_reference_tag_to_courses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->string('reference_tag')->nullable()->after('organization_logo_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropColumn('reference_tag');
+        });
+    }
+};

--- a/resources/js/components/courses/form/course-additionnal.form.tsx
+++ b/resources/js/components/courses/form/course-additionnal.form.tsx
@@ -159,6 +159,18 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSel
                     />
                     <InputError message={errors.lectures} />
                 </div>
+                <div className="grid gap-2">
+                    <Label htmlFor="reference_tag">Tag de références</Label>
+                    <Input
+                        id="reference_tag"
+                        type="text"
+                        value={data.reference_tag ?? ''}
+                        onChange={(e) => setData('reference_tag', e.target.value)}
+                        disabled={processing}
+                        placeholder="Tag de références (ex: audit-conseil)"
+                    />
+                    <InputError message={errors.reference_tag} />
+                </div>
             </div>
         </fieldset>
     );

--- a/resources/js/components/courses/form/course.form.util.ts
+++ b/resources/js/components/courses/form/course.form.util.ts
@@ -38,6 +38,7 @@ export type ICourseRequest = {
     image: string;
 
     partner_ids?: number[];
+    reference_tag?: string;
 
     is_published?: boolean; // Indicate if the course is published or a draft
 };
@@ -68,6 +69,7 @@ export type ICourseForm = {
     is_featured: boolean;
 
     partner_ids?: number[];
+    reference_tag?: string;
 
     media?: File | null; // For thumbnail
     logo: File | null; // For course logo
@@ -161,8 +163,9 @@ export const COURSE_DEFAULT_VALUES: ICourseForm = {
     content: '',
 
     is_featured: false,
-    
+
     partner_ids: [],
+    reference_tag: '',
 
     logo: null,
     organization_logo: null,
@@ -216,6 +219,7 @@ export const createPayload = (data: ICourseForm, draft: boolean): ICourseRequest
             attachment: data.attachment || '',
             is_published: !draft,
             partner_ids: data.partner_ids && data.partner_ids.length > 0 ? data.partner_ids : [],
+            reference_tag: data.reference_tag || '',
         };
 
         console.log('[CREATE_PAYLOAD]', payload);

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -130,6 +130,7 @@ function CourseForm({ course }: ICourseFormProps) {
         setData('image', course.image || '');
         setData('title', course.title || '');
         setData('partner_ids', course.partners ? course.partners.map((p) => p.id!) : []);
+        setData('reference_tag', (course as any).reference_tag || '');
         setSelectedPartners(course.partners ? course.partners.map((p) => p.id!) : []);
 
         // setData('description', course.description || '');

--- a/resources/js/pages/public/courses/course-detail.page.tsx
+++ b/resources/js/pages/public/courses/course-detail.page.tsx
@@ -4,6 +4,8 @@ import Testimonials from '@/components/testimonial/Testimonials';
 import DefaultLayout from '@/layouts/public/front.layout';
 import { SharedData } from '@/types';
 import { ICourse } from '@/types/course';
+import { IPartner } from '@/types/partner';
+import ReferenceLogos from '@/components/references/ReferenceLogos';
 import { Logger } from '@/utils/console.util';
 import { ROUTE_MAP } from '@/utils/route.util';
 import { usePage } from '@inertiajs/react';
@@ -11,6 +13,7 @@ import { useEffect, useState } from 'react';
 
 export default function CourseCategoryPage() {
     const { auth, data } = usePage<SharedData>().props;
+    const references: IPartner[] = (data as any)?.references ?? [];
     const [loading, setLoading] = useState<boolean>(false);
     // const [category, setCategory] = useState<ICourseCategory | null>(null);
     const [course, setCourse] = useState<ICourse | null>(null);
@@ -46,6 +49,7 @@ export default function CourseCategoryPage() {
                         <Hero title={course.title} description={''} course={course} breadcrumbItems={breadcrumb} gradient="style-2" />
                         {/* <OurCurrentCourses coursesData={category.children} showSidebar={true} /> */}
                         <CourseDetail course={course} />
+                        <ReferenceLogos references={references} />
                     </>
                 )}
                 <Testimonials />

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -117,6 +117,7 @@ export interface ICourse {
     gallery?: IMedia[];
     course_sessions?: ICourseSession[];
     partners?: IPartner[];
+    reference_tag?: string;
 
 }
 
@@ -268,6 +269,8 @@ export interface ICustomSharedData {
 
     testimonials?: IDataWithPagination<ITestimonial>
     faqs?: IFaq[]
+
+    references?: IPartner[]
 
     chart_data?: {
         enrollment_area: IChartData;


### PR DESCRIPTION
## Summary
- allow specifying a `reference_tag` when creating or editing a course
- store and update the tag in the course repository
- expose tag references on course details and show reference logos
- support the new field in forms, types, and requests
- add migration for `reference_tag` column on courses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_687a41e8d4f08333ad673f34cba6b336