### PR TITLE
Add partner drawer on course cards

### DIFF
--- a/app/Http/Controllers/Private/CourseController.php
+++ b/app/Http/Controllers/Private/CourseController.php
@@ -66,10 +66,12 @@ class CourseController extends Controller
 
         $categories = CategoryRepository::findAll();
         $courses = CourseRepository::findAll($search);
+        $partners = PartnerRepository::query()->where('is_active', true)->get();
 
         $data = [
             'courses'    => ["list" => $courses],
             'categories' => $categories,
+            'partners'   => $partners,
         ];
 
         return Inertia::render('dashboard/courses/index', [


### PR DESCRIPTION
## Summary
- load partners in dashboard course list
- add drawer on course cards to associate partners

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: TS1005 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cedeadc4883338c57edb50abfb58b