### PR TITLE
Fix null setting access in notification resource

### DIFF
--- a/app/Http/Resources/NotificationInstanceResource.php
+++ b/app/Http/Resources/NotificationInstanceResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Repositories\SettingRepository;
+use App\Models\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -15,7 +16,10 @@ class NotificationInstanceResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $setting = SettingRepository::query()->get()->first();
+        $setting = SettingRepository::query()->first();
+        if (!$setting) {
+            $setting = new Setting();
+        }
 
         return [
             'id' => $this->id,


### PR DESCRIPTION
## Summary
- prevent error in `NotificationInstanceResource` when no setting record exists

## Testing
- `php -l app/Http/Resources/NotificationInstanceResource.php`
- `composer test` *(fails: missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687cf58db5048333a7af8daa5d3aad46