### PR TITLE
Fix course update without existing thumbnail

### DIFF
--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -306,15 +306,15 @@ class CourseRepository extends Repository
                 $isActive = $request->is_active === "on" ?? true;
             }
 
-            $media = $course->media;
-            if ($request->hasFile('media')) {
-                $media = MediaRepository::updateByRequest(
-                    $request->file('media'),
-                    $media,
-                    'course/thumbnail',
-                    MediaTypeEnum::IMAGE
-                );
-            }
+        $media = $course->media;
+        if ($request->hasFile('media')) {
+            $media = MediaRepository::updateOrCreateByRequest(
+                $request->file('media'),
+                'course/thumbnail',
+                $media,
+                MediaTypeEnum::IMAGE
+            );
+        }
 
             $video = $course->video;
             if ($request->hasFile('video')) {


### PR DESCRIPTION
## Summary
- handle course thumbnail updates when no media exists

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_687cfa3b67d0833390ce734b2c7c298c