### PR TITLE
Handle media URLs for course logos

### DIFF
--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 use App\Enum\MediaTypeEnum;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
 
 class Media extends Model
 {
@@ -15,4 +17,19 @@ class Media extends Model
     protected $casts = [
         'type' => MediaTypeEnum::class,
     ];
+
+    protected $appends = ['url'];
+
+    public function url(): Attribute
+    {
+        $url = null;
+
+        if ($this->src && Storage::exists($this->src)) {
+            $url = Storage::url($this->src);
+        }
+
+        return Attribute::make(
+            get: fn() => $url,
+        );
+    }
 }

--- a/resources/js/components/courses/detail/CourseDetail.tsx
+++ b/resources/js/components/courses/detail/CourseDetail.tsx
@@ -1,5 +1,6 @@
 import { CLASS_NAME } from '@/data/styles/style.constant';
 import { ICourse } from '@/types/course';
+import { getMediaUrl } from '@/utils/utils';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CourseDetailAccordion from './CourseDetailAccordion';
@@ -44,14 +45,14 @@ const CourseDetail: React.FC<CourseDetailProps> = ({ course }) => {
                     <div className="mb-6 flex items-center gap-4">
                         {course.logo && (
                             <img
-                                src={course.logo.src}
+                                src={getMediaUrl(course.logo)}
                                 alt={`${course.title} logo`}
                                 className="h-16 w-auto object-contain"
                             />
                         )}
                         {course.organization_logo && (
                             <img
-                                src={course.organization_logo.src}
+                                src={getMediaUrl(course.organization_logo)}
                                 alt="Organization logo"
                                 className="h-16 w-auto object-contain"
                             />

--- a/resources/js/types/course.d.ts
+++ b/resources/js/types/course.d.ts
@@ -21,7 +21,8 @@ export interface IMedia {
     extension: string,
     type: mediaType,
     created_at: string,
-    updated_at: string
+    updated_at: string,
+    url?: string
 }
 
 export type ICoursePeriodicity = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR';

--- a/resources/js/utils/utils.ts
+++ b/resources/js/utils/utils.ts
@@ -1,6 +1,15 @@
 import { SharedData } from "@/types";
-import { ICourse, ICourseCategory, ICoursePeriodicity, ICustomSharedData } from "@/types/course";
+import { ICourse, ICourseCategory, ICoursePeriodicity, ICustomSharedData, IMedia } from "@/types/course";
 import { Logger } from "./console.util";
+
+export const getMediaUrl = (media: IMedia | string | undefined): string => {
+    const src = typeof media === 'string' ? media : media?.url || media?.src;
+    if (!src) return '';
+    if (/^https?:\/\//i.test(src)) {
+        return src;
+    }
+    return `/storage/${src.replace(/^\/+/, '')}`;
+};
 
 const callBackCreateCoursesFromCategory = (category: ICourseCategory): ICourse[] => {
     let courses: ICourse[] = [];


### PR DESCRIPTION
## Summary
- add URL accessor on Media model to generate public paths
- support optional `url` field in `IMedia`
- expose `getMediaUrl` helper for image paths
- display course logos with public URLs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d00cad940833382e8ec861ec2503e