### PR TITLE
Show existing images when editing courses

### DIFF
--- a/resources/js/components/courses/form/course-basic-info.form.tsx
+++ b/resources/js/components/courses/form/course-basic-info.form.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import SelectCustom, { ISelectItem } from '@/components/ui/select-custom';
 import { ICourse, ICourseCategory } from '@/types/course';
 import { Logger } from '@/utils/console.util';
+import { getMediaUrl } from '@/utils/utils';
 import { lazy, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import 'react-quill/dist/quill.snow.css';
@@ -47,6 +48,10 @@ export default function CourseBasicInfoForm({
     onGalleryChange,
 }: CourseBasicInfoFormProps) {
     const { t } = useTranslation();
+
+    const thumbnailPreview = courseSelected?.media ? [getMediaUrl(courseSelected.media)] : undefined;
+    const logoPreview = courseSelected?.logo ? [getMediaUrl(courseSelected.logo)] : undefined;
+    const orgLogoPreview = courseSelected?.organization_logo ? [getMediaUrl(courseSelected.organization_logo)] : undefined;
 
     const category_list = (): ISelectItem[] => {
         return categories.map((category) => ({
@@ -148,6 +153,7 @@ export default function CourseBasicInfoForm({
                             accept="image/*"
                             multiple={false}
                             disabled={processing}
+                            previewUrls={thumbnailPreview}
                         />
                         <InputError message={errors.media} />
                     </div>
@@ -159,6 +165,7 @@ export default function CourseBasicInfoForm({
                             accept="image/*"
                             multiple={false}
                             disabled={processing}
+                            previewUrls={logoPreview}
                         />
                         <InputError message={errors.logo} />
                     </div>
@@ -170,6 +177,7 @@ export default function CourseBasicInfoForm({
                             accept="image/*"
                             multiple={false}
                             disabled={processing}
+                            previewUrls={orgLogoPreview}
                         />
                         <InputError message={errors.organization_logo} />
                     </div>

--- a/resources/js/components/ui/inputFile.tsx
+++ b/resources/js/components/ui/inputFile.tsx
@@ -2,14 +2,16 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 interface InputFileProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  multiple?: boolean;
-  onFilesChange?: (files: FileList | null) => void;
+    multiple?: boolean;
+    onFilesChange?: (files: FileList | null) => void;
+    previewUrls?: string[];
 }
 
 export function InputFile({
     className,
     multiple = false,
     onFilesChange,
+    previewUrls,
     id: propId,
     ...props
 }: InputFileProps) {
@@ -17,6 +19,16 @@ export function InputFile({
     const [previews, setPreviews] = React.useState<{ src: string; type: string }[]>([]);
     const inputRef = React.useRef<HTMLInputElement>(null);
     const id = propId ?? React.useId();
+
+    React.useEffect(() => {
+        if (previewUrls && previewUrls.length > 0) {
+            const urls = previewUrls.map((u) => ({
+                src: u,
+                type: u.split('.').pop()?.startsWith('mp4') ? 'video' : 'image',
+            }));
+            setPreviews(urls);
+        }
+    }, [previewUrls]);
 
   const handleFiles = (files: FileList | null) => {
     if (onFilesChange) onFilesChange(files);


### PR DESCRIPTION
## Summary
- allow file input previews to be set via `previewUrls`
- show existing course images in the edit form

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687d03bdb5648333b1dbf83a07df13b5