### PR TITLE
Fix course description persistence

### DIFF
--- a/app/Repositories/CourseRepository.php
+++ b/app/Repositories/CourseRepository.php
@@ -386,7 +386,10 @@ class CourseRepository extends Repository
                 'organization_logo_id' => $organizationLogo ? $organizationLogo->id : $course->organization_logo_id,
                 'video_id'      => $video ? $video->id : null,
                 'reference_tag' => $request->reference_tag ?? $course->reference_tag,
-                'description'   => json_encode($request->description) ?? $course->description,
+                // description is already sent as a JSON string from the form
+                // so we store it directly without re-encoding it to avoid
+                // nested JSON strings
+                'description'   => $request->description ?? $course->description,
                 'regular_price' => $request->regular_price ?? null,
                 'price'         => $request->price,
                 'instructor_id' => $request->instructor_id ?? $course->instructor_id,


### PR DESCRIPTION
## Summary
- avoid double json encoding when updating a course description

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d0f7901748333a1fadcefb388ddbf