### PR TITLE
Fix rich text style on course detail

### DIFF
--- a/resources/js/components/courses/detail/CourseDetail.tsx
+++ b/resources/js/components/courses/detail/CourseDetail.tsx
@@ -1,4 +1,5 @@
 import { CLASS_NAME } from '@/data/styles/style.constant';
+import 'react-quill/dist/quill.snow.css';
 import { ICourse } from '@/types/course';
 import { getMediaUrl } from '@/utils/utils';
 import { useRef, useState } from 'react';


### PR DESCRIPTION
## Summary
- import Quill CSS in CourseDetail component so description sections render with correct formatting

## Testing
- `composer install --no-progress` *(fails: ext-sodium missing)*
- `npm run lint` *(fails: missing ESLint packages)*
- `npm run types` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d115ce5c88333b5c7a074b2dd7766