### PR TITLE
Add Docker support with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+# ----- Build Stage -----
+FROM php:8.2-fpm-alpine AS build
+
+# Install system dependencies and PHP extensions
+RUN apk add --no-cache git curl bash icu-dev oniguruma-dev zip libpng-dev libjpeg-turbo-dev freetype-dev nodejs npm \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install pdo pdo_mysql pdo_sqlite intl zip bcmath gd opcache
+
+WORKDIR /app
+
+# Copy application source
+COPY . .
+
+# Install PHP and Node dependencies
+RUN composer install --no-dev --optimize-autoloader --no-interaction \
+    && npm install \
+    && npm run build
+
+# ----- Final Stage -----
+FROM php:8.2-fpm-alpine AS final
+
+# Install only runtime dependencies and PHP extensions
+RUN apk add --no-cache bash icu oniguruma libpng libjpeg-turbo freetype \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install pdo pdo_mysql pdo_sqlite intl zip bcmath gd opcache
+
+WORKDIR /app
+
+# Copy built application from the build stage
+COPY --from=build /app /app
+
+# Ensure correct permissions for writable directories
+RUN chown -R www-data:www-data storage bootstrap/cache
+
+USER www-data
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,9 +13,42 @@ services:
     # env_file: ./.env  # Uncomment if .env file exists
     networks:
       - appnet
-    # If you use a database or cache, add depends_on here
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    container_name: db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: root
+      MYSQL_USER: jerry_clexcellence
+      MYSQL_PASSWORD: root
+    volumes:
+      - dbdata:/var/lib/mysql
+    networks:
+      - appnet
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      PMA_HOST: db
+      PMA_USER: jerry_clexcellence
+      PMA_PASSWORD: root
+    ports:
+      - "8080:80"
+    networks:
+      - appnet
 
 # Network for inter-service communication
 networks:
   appnet:
     driver: bridge
+
+volumes:
+  dbdata:

--- a/config.inc.php
+++ b/config.inc.php
@@ -12,7 +12,7 @@
  * This is needed for cookie based authentication to encrypt the cookie.
  * Needs to be a 32-bytes long string of random bytes. See FAQ 2.10.
  */
-$cfg['blowfish_secret'] = ''; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
+$cfg['blowfish_secret'] = 'change_this_secret';
 
 /**
  * Servers configuration
@@ -26,7 +26,7 @@ $i++;
 /* Authentication type */
 $cfg['Servers'][0]['auth_type'] = 'cookie';
 /* Server parameters */
-$cfg['Servers'][$i]['host'] = '51.44.177.27';
+$cfg['Servers'][$i]['host'] = 'db';
 //$cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 //$cfg['Servers'][$i]['verbose'] = 'Remote DB (51.44.177.27)';

--- a/database/migrations/2025_07_20_000000_create_photos_table.php
+++ b/database/migrations/2025_07_20_000000_create_photos_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('photos', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('title');
+            $table->string('path');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('photos');
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,41 @@ services:
     # env_file: ./.env
     networks:
       - appnet
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    container_name: db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: root
+      MYSQL_USER: jerry_clexcellence
+      MYSQL_PASSWORD: root
+    volumes:
+      - dbdata:/var/lib/mysql
+    networks:
+      - appnet
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: phpmyadmin
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      PMA_HOST: db
+      PMA_USER: jerry_clexcellence
+      PMA_PASSWORD: root
+    ports:
+      - "8080:80"
+    networks:
+      - appnet
 
 networks:
   appnet:
     driver: bridge
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  php-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: final
+    container_name: php-app
+    restart: unless-stopped
+    init: true
+    ports:
+      - "9000:9000"
+    # env_file: ./.env
+    networks:
+      - appnet
+
+networks:
+  appnet:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add a multistage `Dockerfile` for building and running the Laravel app
- provide `docker-compose.yml` to build and run the container

## Testing
- `composer test` *(fails: failed opening required '/workspace/server/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_687d4202da448333868544df49864f22