### PR TITLE
Add API to sync course partners and filter UI

### DIFF
--- a/app/Http/Requests/CoursePartnerSyncRequest.php
+++ b/app/Http/Requests/CoursePartnerSyncRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CoursePartnerSyncRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'partner_ids' => 'sometimes|array',
+            'partner_ids.*' => 'exists:partners,id',
+        ];
+    }
+}

--- a/resources/js/components/courses/card/courseCard.tsx
+++ b/resources/js/components/courses/card/courseCard.tsx
@@ -25,6 +25,7 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete, setOpenSessio
     const [openPartnerDrawer, setOpenPartnerDrawer] = useState(false);
     const [partners, setPartners] = useState<IPartner[]>([]);
     const [selectedPartners, setSelectedPartners] = useState<number[]>(course.partners ? course.partners.map((p) => p.id!) : []);
+    const [partnerFilter, setPartnerFilter] = useState('');
 
     useEffect(() => {
         if ((data as any)?.partners) {
@@ -34,8 +35,7 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete, setOpenSessio
 
     const handleUpdatePartners = async () => {
         try {
-            await axios.post(route('dashboard.course.update', course.slug), {
-                _method: 'PUT',
+            await axios.post(route('dashboard.course.partners.sync', course.slug), {
                 partner_ids: selectedPartners,
             });
             toast.success('Partenaires associés');
@@ -194,7 +194,16 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete, setOpenSessio
                 setOpen={setOpenPartnerDrawer}
                 component={
                     <div className="space-y-2">
-                        {partners.map((p) => (
+                        <input
+                            type="text"
+                            className="w-full rounded border p-2"
+                            placeholder="Rechercher..."
+                            value={partnerFilter}
+                            onChange={(e) => setPartnerFilter(e.target.value)}
+                        />
+                        {partners
+                            .filter((p) => p.name.toLowerCase().includes(partnerFilter.toLowerCase()))
+                            .map((p) => (
                             <label key={p.id} className="flex items-center space-x-2">
                                 <input
                                     type="checkbox"
@@ -211,7 +220,7 @@ const CourseCard: React.FC<CourseCardProps> = ({ course, onDelete, setOpenSessio
                                 />
                                 <span>{p.name}</span>
                             </label>
-                        ))}
+                            ))}
                         <Button className="mt-2" onClick={handleUpdatePartners}>
                             Enregistrer
                         </Button>

--- a/resources/js/components/courses/form/course-additionnal.form.tsx
+++ b/resources/js/components/courses/form/course-additionnal.form.tsx
@@ -24,9 +24,10 @@ interface CourseAdditionnalFormProps {
     setData: (data: string, value: string | number) => void;
     processing: boolean;
     errors: ICourseFormErrors;
+    partnerTags?: string[];
 }
 
-export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSelected, setData, processing, errors }: CourseAdditionnalFormProps) {
+export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSelected, setData, processing, errors, partnerTags = [] }: CourseAdditionnalFormProps) {
     const [displayPrice, setDisplayPrice] = useState<string>(() => (data.price ? Number(data.price).toLocaleString('fr-FR') : ''));
 
     useEffect(() => {
@@ -167,6 +168,7 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSel
                 <div className="grid gap-2">
                     <Label htmlFor="reference_tag">Tag de références</Label>
                     <Input
+                        list="partner-tags"
                         id="reference_tag"
                         type="text"
                         value={data.reference_tag ?? ''}
@@ -174,6 +176,11 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSel
                         disabled={processing}
                         placeholder="Tag de références (ex: audit-conseil)"
                     />
+                    <datalist id="partner-tags">
+                        {partnerTags.map((tag) => (
+                            <option key={tag} value={tag} />
+                        ))}
+                    </datalist>
                     <InputError message={errors.reference_tag} />
                 </div>
             </div>

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -66,6 +66,14 @@ function CourseForm({ course }: ICourseFormProps) {
     const [selectedPartners, setSelectedPartners] = useState<number[]>([]);
     const [openPartnerDrawer, setOpenPartnerDrawer] = useState(false);
     const [partnerFilter, setPartnerFilter] = useState('');
+    const partnerTags = Array.from(
+        new Set(
+            partners
+                .map((p) => p.tag)
+                .filter(Boolean)
+                .flatMap((t) => t!.split(';').filter(Boolean))
+        )
+    );
     const [thumbnail, setThumbnail] = useState<File | null>(null);
     const [logoFile, setLogoFile] = useState<File | null>(null);
     const [orgLogoFile, setOrgLogoFile] = useState<File | null>(null);
@@ -320,6 +328,7 @@ function CourseForm({ course }: ICourseFormProps) {
                                                 setData={setData}
                                                 processing={processing}
                                                 errors={errors}
+                                                partnerTags={partnerTags}
                                             />
                                         </div>
 

--- a/resources/js/components/courses/form/edit-course.form.tsx
+++ b/resources/js/components/courses/form/edit-course.form.tsx
@@ -65,6 +65,7 @@ function CourseForm({ course }: ICourseFormProps) {
     const [partners, setPartners] = useState<IPartner[]>([]);
     const [selectedPartners, setSelectedPartners] = useState<number[]>([]);
     const [openPartnerDrawer, setOpenPartnerDrawer] = useState(false);
+    const [partnerFilter, setPartnerFilter] = useState('');
     const [thumbnail, setThumbnail] = useState<File | null>(null);
     const [logoFile, setLogoFile] = useState<File | null>(null);
     const [orgLogoFile, setOrgLogoFile] = useState<File | null>(null);
@@ -453,7 +454,16 @@ function CourseForm({ course }: ICourseFormProps) {
                 setOpen={setOpenPartnerDrawer}
                 component={
                     <div className="space-y-2">
-                        {partners.map((p) => (
+                        <input
+                            type="text"
+                            className="w-full rounded border p-2"
+                            placeholder="Rechercher..."
+                            value={partnerFilter}
+                            onChange={(e) => setPartnerFilter(e.target.value)}
+                        />
+                        {partners
+                            .filter((p) => p.name.toLowerCase().includes(partnerFilter.toLowerCase()))
+                            .map((p) => (
                             <label key={p.id} className="flex items-center space-x-2">
                                 <input
                                     type="checkbox"

--- a/resources/js/components/partners/partnerForm.tsx
+++ b/resources/js/components/partners/partnerForm.tsx
@@ -1,5 +1,5 @@
 import { router, useForm } from '@inertiajs/react';
-import { FormEventHandler, useState } from 'react';
+import { FormEventHandler, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import InputError from '@/components/input-error';
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { InputFile } from '@/components/ui/inputFile';
+import TagInput from '@/components/ui/tag-input';
 import { IPartner } from '@/types/partner';
 
 interface PartnerFormProps {
@@ -17,6 +18,7 @@ interface PartnerFormProps {
 const defaultValues: IPartner = {
     name: '',
     link: '',
+    tag: '',
     is_active: true,
 };
 
@@ -24,6 +26,11 @@ export default function PartnerForm({ closeDrawer, initialData }: PartnerFormPro
     const { t } = useTranslation();
     const [file, setFile] = useState<File | null>(null);
     const { data, setData, processing, errors, reset } = useForm<IPartner>(initialData || defaultValues);
+    const [tags, setTags] = useState<string[]>(initialData?.tag ? initialData.tag.split(';').filter(Boolean) : []);
+
+    useEffect(() => {
+        setData('tag', tags.join(';'));
+    }, [tags]);
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -40,6 +47,7 @@ export default function PartnerForm({ closeDrawer, initialData }: PartnerFormPro
             data: {
                 name: data.name,
                 link: data.link,
+                tag: data.tag,
                 ...(file && { picture: file }),
                 is_active: data.is_active ? '1' : '0',
             },
@@ -64,6 +72,11 @@ export default function PartnerForm({ closeDrawer, initialData }: PartnerFormPro
                 <Label htmlFor="link">{t('Link', 'Lien')}</Label>
                 <Input id="link" value={data.link ?? ''} onChange={(e) => setData('link', e.target.value)} disabled={processing} />
                 <InputError message={errors.link} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="tag">Tag de référence</Label>
+                <TagInput tags={tags} onChange={setTags} placeholder="tag1;tag2" />
+                <InputError message={errors.tag} />
             </div>
             <div className="grid gap-2">
                 <Label htmlFor="picture">{t('Image')}</Label>

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -46,6 +46,7 @@ Route::middleware(['auth', 'verified'])->prefix('dashboard')->group(function () 
         Route::get('create',            [CourseController::class, 'create'])->name('dashboard.course.create');
         Route::post('create',           [CourseController::class, 'store'])->name('dashboard.course.store');
         Route::put('update/{slug}',     [CourseController::class, 'update'])->name('dashboard.course.update');
+        Route::post('partners/{slug}',  [CourseController::class, 'syncPartners'])->name('dashboard.course.partners.sync');
         Route::delete('delete/{id}',    [CourseController::class, 'delete'])->name('dashboard.course.delete');
         Route::post('{course}/sessions', [CourseSessionController::class, 'store'])->name('dashboard.course.session.store');
     });


### PR DESCRIPTION
## Summary
- add `CoursePartnerSyncRequest` for validating partner sync
- expose `syncPartners` endpoint on course controller and route
- update partner drawer in course components with filter input
- allow updating partners via new API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d581e456483339b235c931a6f77c7