### PR TITLE
Fix periodicity select default value

### DIFF
--- a/resources/js/components/courses/form/course-additionnal.form.tsx
+++ b/resources/js/components/courses/form/course-additionnal.form.tsx
@@ -32,10 +32,16 @@ export default function CourseAdditionnalForm({ fieldsetClasses, data, courseSel
     useEffect(() => {
         setDisplayPrice(data.price ? Number(data.price).toLocaleString('fr-FR') : '');
         if(courseSelected ) {
-            courseSelected.price && data.price == '' && setData('price', courseSelected.price.toString()); 
+            courseSelected.price && data.price == '' && setData('price', courseSelected.price.toString());
         }
     }, [data.price]);
     const { t } = useTranslation();
+
+    useEffect(() => {
+        if (courseSelected && !data.periodicity_unit) {
+            setData('periodicity_unit', courseSelected.periodicity_unit);
+        }
+    }, [courseSelected, data.periodicity_unit]);
 
     return (
         <fieldset className={fieldsetClasses}>


### PR DESCRIPTION
## Summary
- ensure the course additional form pre-selects periodicity when editing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d589e9ecc83338abbf15eabb5f844