### PR TITLE
Add contact buttons for enrollments

### DIFF
--- a/resources/js/components/enrollments/EnrollmentDataTable.tsx
+++ b/resources/js/components/enrollments/EnrollmentDataTable.tsx
@@ -1,6 +1,6 @@
 import { ICourseEnrollment } from '@/types/course';
 import { ColumnDef } from '@tanstack/react-table';
-import { ArrowUpDown, Trash2 } from 'lucide-react';
+import { ArrowUpDown, Mail, Phone, Trash2 } from 'lucide-react';
 import { Button } from '../ui/button/button';
 import { DataTable } from '../ui/dataTable';
 
@@ -40,6 +40,30 @@ export default function EnrollmentDataTable({ enrollments, onDeleteRow }: Enroll
                 </Button>
             ),
             cell: ({ row }) => <span>{row.original.user?.phone || '-'}</span>,
+        },
+        {
+            id: 'contact',
+            header: 'Contact',
+            cell: ({ row }) => (
+                <div className="flex space-x-2">
+                    {row.original.user?.email && (
+                        <Button variant="ghost" size="icon" asChild>
+                            <a href={`mailto:${row.original.user.email}`}>
+                                <Mail className="h-4 w-4" />
+                                <span className="sr-only">Mail</span>
+                            </a>
+                        </Button>
+                    )}
+                    {row.original.user?.phone && (
+                        <Button variant="ghost" size="icon" asChild>
+                            <a href={`tel:${row.original.user.phone}`}>
+                                <Phone className="h-4 w-4" />
+                                <span className="sr-only">Téléphone</span>
+                            </a>
+                        </Button>
+                    )}
+                </div>
+            ),
         },
         {
             accessorKey: 'course',


### PR DESCRIPTION
## Summary
- add Mail and Phone icons to enrollment table
- allow contacting enrolled users via mail or phone

## Testing
- `npm run format:check` *(fails: Cannot find package)*
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_687d5ae1fa788333a4c695f335e6e781