### PR TITLE
Fix reference creation and image storage

### DIFF
--- a/app/Http/Controllers/Private/ReferenceController.php
+++ b/app/Http/Controllers/Private/ReferenceController.php
@@ -38,9 +38,6 @@ class ReferenceController extends Controller
 
     public function store(PartnerStoreRequest $request)
     {
-        if (app()->isLocal()) {
-            return to_route('dashboard.references.index')->with('error', 'Reference not created in demo mode');
-        }
 
         $request->merge(['is_reference' => true]);
 

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -68,8 +68,8 @@ class Blog extends Model
     {
         $media = 'https://placehold.co/600x400';
 
-        if ($this->media && Storage::exists($this->media->src)) {
-            $media = Storage::url($this->media->src);
+        if ($this->media && Storage::disk('public')->exists($this->media->src)) {
+            $media = Storage::disk('public')->url($this->media->src);
         }
 
         return Attribute::make(

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -50,8 +50,8 @@ class Category extends Model
     {
         $image = 'https://placehold.co/512x512';
 
-        if ($this->image && Storage::exists($this->image->src)) {
-            $image = Storage::url($this->image->src);
+        if ($this->image && Storage::disk('public')->exists($this->image->src)) {
+            $image = Storage::disk('public')->url($this->image->src);
         }
 
         return Attribute::make(

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -61,8 +61,8 @@ class Course extends Model
     {
         $media = 'https://placehold.co/600x400';
 
-        if ($this->media && Storage::exists($this->media->src)) {
-            $media = Storage::url($this->media->src);
+        if ($this->media && Storage::disk('public')->exists($this->media->src)) {
+            $media = Storage::disk('public')->url($this->media->src);
         }
 
         return Attribute::make(
@@ -79,8 +79,8 @@ class Course extends Model
     {
         $video = null;
 
-        if ($this->video && Storage::exists($this->video->src)) {
-            $video = Storage::url($this->video->src);
+        if ($this->video && Storage::disk('public')->exists($this->video->src)) {
+            $video = Storage::disk('public')->url($this->video->src);
         }
 
         return Attribute::make(
@@ -96,7 +96,7 @@ class Course extends Model
     public function galleryPaths(): Attribute
     {
         $paths = $this->gallery->map(function ($media) {
-            return Storage::exists($media->src) ? Storage::url($media->src) : null;
+            return Storage::disk('public')->exists($media->src) ? Storage::disk('public')->url($media->src) : null;
         })->filter()->values()->toArray();
 
         return Attribute::make(
@@ -113,8 +113,8 @@ class Course extends Model
     {
         $logo = null;
 
-        if ($this->logo && Storage::exists($this->logo->src)) {
-            $logo = Storage::url($this->logo->src);
+        if ($this->logo && Storage::disk('public')->exists($this->logo->src)) {
+            $logo = Storage::disk('public')->url($this->logo->src);
         }
 
         return Attribute::make(
@@ -131,8 +131,8 @@ class Course extends Model
     {
         $logo = null;
 
-        if ($this->organizationLogo && Storage::exists($this->organizationLogo->src)) {
-            $logo = Storage::url($this->organizationLogo->src);
+        if ($this->organizationLogo && Storage::disk('public')->exists($this->organizationLogo->src)) {
+            $logo = Storage::disk('public')->url($this->organizationLogo->src);
         }
 
         return Attribute::make(

--- a/app/Models/Instructor.php
+++ b/app/Models/Instructor.php
@@ -65,8 +65,8 @@ class Instructor extends Model
     {
         $signature = asset('enrollment/upload.png');
 
-        if ($this->signature && Storage::exists($this->signature->src)) {
-            $signature = Storage::url($this->signature->src);
+        if ($this->signature && Storage::disk('public')->exists($this->signature->src)) {
+            $signature = Storage::disk('public')->url($this->signature->src);
         }
 
         return Attribute::make(

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -24,8 +24,8 @@ class Media extends Model
     {
         $url = null;
 
-        if ($this->src && Storage::exists($this->src)) {
-            $url = Storage::url($this->src);
+        if ($this->src && Storage::disk('public')->exists($this->src)) {
+            $url = Storage::disk('public')->url($this->src);
         }
 
         return Attribute::make(

--- a/app/Models/Partner.php
+++ b/app/Models/Partner.php
@@ -28,8 +28,8 @@ class Partner extends Model
     public function mediaPath(): Attribute
     {
         $media = null;
-        if ($this->media && Storage::exists($this->media->src)) {
-            $media = Storage::url($this->media->src);
+        if ($this->media && Storage::disk('public')->exists($this->media->src)) {
+            $media = Storage::disk('public')->url($this->media->src);
         }
 
         return Attribute::make(

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -23,8 +23,8 @@ class Setting extends Model
     {
         $logo = asset('assets/images/logo-new.png');
 
-        if ($this->logo && Storage::exists($this->logo->src)) {
-            $logo = Storage::url($this->logo->src);
+        if ($this->logo && Storage::disk('public')->exists($this->logo->src)) {
+            $logo = Storage::disk('public')->url($this->logo->src);
         }
 
         return Attribute::make(
@@ -40,8 +40,8 @@ class Setting extends Model
     {
         $footer = asset('assets/images/logo-new.png');
 
-        if ($this->footer && Storage::exists($this->footer->src)) {
-            $footer = Storage::url($this->footer->src);
+        if ($this->footer && Storage::disk('public')->exists($this->footer->src)) {
+            $footer = Storage::disk('public')->url($this->footer->src);
         }
 
         return Attribute::make(
@@ -58,8 +58,8 @@ class Setting extends Model
     {
         $favicon = asset('assets/images/favicon.ico');
 
-        if ($this->favicon && Storage::exists($this->favicon->src)) {
-            $favicon = Storage::url($this->favicon->src);
+        if ($this->favicon && Storage::disk('public')->exists($this->favicon->src)) {
+            $favicon = Storage::disk('public')->url($this->favicon->src);
         }
 
         return Attribute::make(
@@ -76,8 +76,8 @@ class Setting extends Model
     {
         $scaner = asset('assets/website/scaner/scan.png');
 
-        if ($this->scaner && Storage::exists($this->scaner->src)) {
-            $scaner = Storage::url($this->scaner->src);
+        if ($this->scaner && Storage::disk('public')->exists($this->scaner->src)) {
+            $scaner = Storage::disk('public')->url($this->scaner->src);
         }
 
         return Attribute::make(

--- a/app/Models/Testimonial.php
+++ b/app/Models/Testimonial.php
@@ -26,8 +26,8 @@ class Testimonial extends Model
     {
         $media = asset('media/blank-user.png');
 
-        if ($this->media && Storage::exists($this->media->src)) {
-            $media = Storage::url($this->media->src);
+        if ($this->media && Storage::disk('public')->exists($this->media->src)) {
+            $media = Storage::disk('public')->url($this->media->src);
         }
 
         return Attribute::make(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -78,8 +78,8 @@ class User extends Authenticatable implements JWTSubject, MustVerifyEmail
     {
         $profilePicture = asset('media/blank-user.png');
 
-        if ($this->profilePicture && Storage::exists($this->profilePicture->src)) {
-            $profilePicture = Storage::url($this->profilePicture->src);
+        if ($this->profilePicture && Storage::disk('public')->exists($this->profilePicture->src)) {
+            $profilePicture = Storage::disk('public')->url($this->profilePicture->src);
         }
 
         return Attribute::make(
@@ -171,8 +171,8 @@ class User extends Authenticatable implements JWTSubject, MustVerifyEmail
     {
         $signature = asset('enrollment/upload.png');
 
-        if ($this->signature && Storage::exists($this->signature->src)) {
-            $signature = Storage::url($this->signature->src);
+        if ($this->signature && Storage::disk('public')->exists($this->signature->src)) {
+            $signature = Storage::disk('public')->url($this->signature->src);
         }
 
         return Attribute::make(

--- a/app/Repositories/FrameRepository.php
+++ b/app/Repositories/FrameRepository.php
@@ -15,7 +15,7 @@ class FrameRepository extends Repository
 
     public static function storeByRequest(UploadedFile $file, $path, $type = null): Frame
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
 
         return self::create([
             'extension' => $file->extension(),
@@ -34,7 +34,7 @@ class FrameRepository extends Repository
         $fileName = basename($filePath); // Get the filename
 
         // Use Storage to put the file content into the specified directory
-        $src = Storage::put('/' . trim($path, '/') . '/' . $fileName, $fileContents, 'public');
+        $src = Storage::disk('public')->put('/' . trim($path, '/') . '/' . $fileName, $fileContents);
 
         // Return a new Media record with the stored file details
         return self::create([
@@ -47,10 +47,9 @@ class FrameRepository extends Repository
 
     public static function updateByRequest(UploadedFile $file, Frame $frame, $path, $type = null): Frame
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
-
-        if (Storage::exists($frame->src)) {
-            Storage::delete($frame->src);
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
+        if (Storage::disk('public')->exists($frame->src)) {
+            Storage::disk('public')->delete($frame->src);
         }
 
         self::update($frame, [
@@ -65,10 +64,9 @@ class FrameRepository extends Repository
 
     public static function updateOrCreateByRequest(UploadedFile $file, $path, $frame = null, $type = null): Frame
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
-
-        if ($frame && Storage::exists($frame->src)) {
-            Storage::delete($frame->src);
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
+        if ($frame && Storage::disk('public')->exists($frame->src)) {
+            Storage::disk('public')->delete($frame->src);
         }
 
         $frame = self::query()->updateOrCreate([

--- a/app/Repositories/MediaRepository.php
+++ b/app/Repositories/MediaRepository.php
@@ -22,7 +22,7 @@ class MediaRepository extends Repository
 
     public static function storeByRequest(UploadedFile $file, $path, $type = null): Media
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
 
         return self::create([
             'extension' => $file->extension(),
@@ -41,7 +41,7 @@ class MediaRepository extends Repository
         $fileName = basename($filePath); // Get the filename
 
         // Use Storage to put the file content into the specified directory
-        $src = Storage::put('/' . trim($path, '/') . '/' . $fileName, $fileContents, 'public');
+        $src = Storage::disk('public')->put('/' . trim($path, '/') . '/' . $fileName, $fileContents);
 
         // Return a new Media record with the stored file details
         return self::create([
@@ -54,10 +54,9 @@ class MediaRepository extends Repository
 
     public static function updateByRequest(UploadedFile $file, Media $media, $path, $type = null): Media
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
-
-        if (Storage::exists($media->src)) {
-            Storage::delete($media->src);
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
+        if (Storage::disk('public')->exists($media->src)) {
+            Storage::disk('public')->delete($media->src);
         }
 
         self::update($media, [
@@ -72,10 +71,9 @@ class MediaRepository extends Repository
 
     public static function updateOrCreateByRequest(UploadedFile $file, $path, $media = null, $type = null): Media
     {
-        $src = Storage::put('/' . trim($path, '/'), $file, 'public');
-
-        if ($media && Storage::exists($media->src)) {
-            Storage::delete($media->src);
+        $src = Storage::disk('public')->put('/' . trim($path, '/'), $file);
+        if ($media && Storage::disk('public')->exists($media->src)) {
+            Storage::disk('public')->delete($media->src);
         }
 
         $media = self::query()->updateOrCreate([


### PR DESCRIPTION
## Summary
- allow creating references in local env
- ensure all media operations use the public disk
- update models to read from the public disk

## Testing
- `npm run format:check` *(fails: Cannot find package `prettier-plugin-tailwindcss`)*
- `composer install` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d610bf11c8333822e2aa7ee876d68