### PR TITLE
Add job offer expiration date

### DIFF
--- a/app/Http/Controllers/Public/PublicJobController.php
+++ b/app/Http/Controllers/Public/PublicJobController.php
@@ -18,7 +18,13 @@ class PublicJobController extends Controller
 
     public function list()
     {
-        $offers = JobOfferRepository::query()->where('is_active', true)->latest('id')->get();
+        $offers = JobOfferRepository::query()
+            ->where('is_active', true)
+            ->where(function ($query) {
+                $query->whereNull('expires_at')->orWhere('expires_at', '>=', now());
+            })
+            ->latest('id')
+            ->get();
         $data['job_offers'] = $offers;
         return Inertia::render('public/careers/careers', [
             'data' => $data,

--- a/app/Http/Requests/JobOfferStoreRequest.php
+++ b/app/Http/Requests/JobOfferStoreRequest.php
@@ -20,6 +20,7 @@ class JobOfferStoreRequest extends FormRequest
             'type' => 'nullable|string',
             'salary' => 'nullable|integer',
             'description' => 'nullable|string',
+            'expires_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/JobOfferUpdateRequest.php
+++ b/app/Http/Requests/JobOfferUpdateRequest.php
@@ -20,6 +20,7 @@ class JobOfferUpdateRequest extends FormRequest
             'type' => 'nullable|string',
             'salary' => 'nullable|integer',
             'description' => 'nullable|string',
+            'expires_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Models/JobOffer.php
+++ b/app/Models/JobOffer.php
@@ -14,6 +14,7 @@ class JobOffer extends Model
 
     protected $casts = [
         'salary' => 'float',
+        'expires_at' => 'datetime',
         'created_at' => 'datetime:D M Y',
         'updated_at' => 'datetime:Y-m-d H:i:s',
     ];

--- a/app/Repositories/JobOfferRepository.php
+++ b/app/Repositories/JobOfferRepository.php
@@ -21,6 +21,7 @@ class JobOfferRepository extends Repository
             'type' => $request->type,
             'salary' => $request->salary,
             'description' => $request->description,
+            'expires_at' => $request->expires_at,
             'is_active' => $request->has('is_active') ? true : false,
         ]);
     }
@@ -34,6 +35,7 @@ class JobOfferRepository extends Repository
             'type' => $request->type ?? $offer->type,
             'salary' => $request->salary ?? $offer->salary,
             'description' => $request->description ?? $offer->description,
+            'expires_at' => $request->expires_at ?? $offer->expires_at,
             'is_active' => $request->has('is_active') ? true : $offer->is_active,
         ]);
     }

--- a/database/migrations/2025_07_12_050600_add_expires_at_to_job_offers_table.php
+++ b/database/migrations/2025_07_12_050600_add_expires_at_to_job_offers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_offers', function (Blueprint $table) {
+            $table->timestamp('expires_at')->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_offers', function (Blueprint $table) {
+            $table->dropColumn('expires_at');
+        });
+    }
+};

--- a/database/seeders/JobOfferSeeder.php
+++ b/database/seeders/JobOfferSeeder.php
@@ -301,6 +301,7 @@ class JobOfferSeeder extends Seeder
         ];
 
         foreach ($offers as $offer) {
+            $offer['expires_at'] = now()->addMonth();
             JobOfferRepository::create($offer);
         }
     }

--- a/resources/js/components/careers/JobCard.tsx
+++ b/resources/js/components/careers/JobCard.tsx
@@ -41,6 +41,9 @@ export const JobCard: React.FC<{
                 </p>
             )}
             <p className="text-gray-600 dark:text-gray-300 mt-2 line-clamp-2">{job.description}</p>
+            {job.expires_at && (
+                <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">Expire le {job.expires_at}</p>
+            )}
             <p className="text-sm text-gray-400 dark:text-gray-500 mt-2">Publié le {job.created_at}</p>
             <BtnSecondary
                 label="Postuler"

--- a/resources/js/components/careers/JobTable.tsx
+++ b/resources/js/components/careers/JobTable.tsx
@@ -19,6 +19,7 @@ export const JobTable: React.FC<{
                         <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Entreprise</th>
                         <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Localité</th>
                         <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Type</th>
+                        <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Expire le</th>
                         <th className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-200">Action</th>
                     </tr>
                 </thead>
@@ -30,6 +31,7 @@ export const JobTable: React.FC<{
                                 <td className="px-4 py-2 whitespace-nowrap">{job.company}</td>
                                 <td className="px-4 py-2 whitespace-nowrap">{job.location}</td>
                                 <td className="px-4 py-2 whitespace-nowrap">{job.type}</td>
+                                <td className="px-4 py-2 whitespace-nowrap">{job.expires_at}</td>
                                 <td className="px-4 py-2 whitespace-nowrap">
                                     <BtnSecondary
                                         label="Postuler"

--- a/resources/js/components/job-offers/jobOfferDataTable.tsx
+++ b/resources/js/components/job-offers/jobOfferDataTable.tsx
@@ -40,6 +40,10 @@ export default function JobOfferDataTable({ offers, onEditRow, onDeleteRow, onTo
             ),
         },
         {
+            accessorKey: 'expires_at',
+            header: 'Expire le',
+        },
+        {
             accessorKey: 'is_active',
             header: 'Active',
             cell: ({ row }) => (row.original.is_active ? 'Oui' : 'Non'),

--- a/resources/js/components/job-offers/jobOfferForm.tsx
+++ b/resources/js/components/job-offers/jobOfferForm.tsx
@@ -19,6 +19,7 @@ const defaultValues: IJobOffer = {
     type: '',
     salary: 0,
     description: '',
+    expires_at: '',
     is_active: true,
 };
 
@@ -70,6 +71,10 @@ export default function JobOfferForm({ closeDrawer, initialData }: Props) {
             <div className="grid gap-2">
                 <Label htmlFor="salary">Salaire</Label>
                 <Input id="salary" type="number" value={data.salary || ''} onChange={(e) => setData('salary', Number(e.target.value))} disabled={processing} />
+            </div>
+            <div className="grid gap-2">
+                <Label htmlFor="expires_at">Date de fin</Label>
+                <Input id="expires_at" type="date" value={data.expires_at || ''} onChange={(e) => setData('expires_at', e.target.value)} disabled={processing} />
             </div>
             <div className="grid gap-2">
                 <Label htmlFor="description">Description</Label>

--- a/resources/js/types/job-offer.d.ts
+++ b/resources/js/types/job-offer.d.ts
@@ -6,6 +6,7 @@ export interface IJobOffer {
     type?: string;
     salary?: number;
     description?: string;
+    expires_at?: string | null;
     is_active?: boolean;
     created_at?: string;
     updated_at?: string;


### PR DESCRIPTION
## Summary
- add expires_at column to job offers
- allow end date in job offer forms and TypeScript types
- store and update expiry date in repository
- filter expired offers from public job list
- display expiry date in front- and back-office tables
- seeders now set an expiry date for demo offers

## Testing
- `composer test` *(fails: composer not installed)*
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d7feed83c8333a750de083217856b