### PR TITLE
Fix image fallback behavior

### DIFF
--- a/resources/js/components/courses/detail/CouseDetailMedia.tsx
+++ b/resources/js/components/courses/detail/CouseDetailMedia.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { ICourse } from '@/types/course';
 import { getMediaUrl } from '@/utils/utils';
 
@@ -6,6 +8,7 @@ interface CouseDetailMediaProps {
 }
 
 export default function CouseDetailMedia({ course }: CouseDetailMediaProps) {
+    const [failed, setFailed] = useState<Record<number, boolean>>({});
     if (!course || !course.media) {
         return (
             <div className="p-4">
@@ -21,7 +24,16 @@ export default function CouseDetailMedia({ course }: CouseDetailMediaProps) {
             {[course.media]
                 ?.filter((media) => media.type === 'image')
                 .map((media, index) => (
-                    <img key={index} src={getMediaUrl(media.src)} alt={course.title} className="w-full h-auto rounded-lg  object-cover" />
+                    failed[index] ? null : (
+                        <img
+                            key={index}
+                            src={getMediaUrl(media.src)}
+                            alt={course.title}
+                            className="w-full h-auto rounded-lg object-cover"
+                            loading="lazy"
+                            onError={() => setFailed((prev) => ({ ...prev, [index]: true }))}
+                        />
+                    )
                 ))}
         </div>
     );


### PR DESCRIPTION
## Summary
- skip broken images in course details
- add lazy loading to media images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: parsing errors in TS files)*

------
https://chatgpt.com/codex/tasks/task_e_687ef384d7b083339c10a098ab098b2c