### PR TITLE
Add Slate text editor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
         "react-quill": "^2.0.0",
         "react-quill-new": "^3.4.6",
         "react-svg": "^16.3.0",
+        "slate": "^0.98.0",
+        "slate-react": "^0.98.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",

--- a/resources/js/components/ui/form/RichTextSlate.tsx
+++ b/resources/js/components/ui/form/RichTextSlate.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo, useCallback } from 'react';
+import { createEditor, Descendant } from 'slate';
+import { Slate, Editable, withReact } from 'slate-react';
+
+interface RichTextSlateProps {
+    label: string;
+    labelId: string;
+    value: string;
+    setData: (value: string) => void;
+    className?: string;
+}
+
+const DEFAULT_VALUE: Descendant[] = [
+    { type: 'paragraph', children: [{ text: '' }] },
+];
+
+export default function RichTextSlate({ label, labelId, value, setData, className = 'min-h-[200px] max-h-[300px] h-fit w-full overflow-y-auto' }: RichTextSlateProps) {
+    const editor = useMemo(() => withReact(createEditor()), []);
+
+    const initialValue = useMemo<Descendant[]>(() => {
+        try {
+            return value ? JSON.parse(value) : DEFAULT_VALUE;
+        } catch {
+            return DEFAULT_VALUE;
+        }
+    }, [value]);
+
+    const handleChange = useCallback(
+        (val: Descendant[]) => {
+            setData(JSON.stringify(val));
+        },
+        [setData]
+    );
+
+    return (
+        <div className="w-full">
+            <label htmlFor={labelId} className="block text-sm font-medium text-gray-700 mb-1">
+                {label}
+            </label>
+            <Slate editor={editor} value={initialValue} onChange={handleChange}>
+                <Editable id={labelId} className={`p-4 border border-gray-300 rounded-lg ${className}`} />
+            </Slate>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add Slate-based rich text editor component
- declare `slate` and `slate-react` dependencies

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f008b22d88333be3eb558b754481d