### PR TITLE
Add CKEditor text editor component

### DIFF
--- a/resources/js/components/ui/form/RichTextCKEditor.tsx
+++ b/resources/js/components/ui/form/RichTextCKEditor.tsx
@@ -1,0 +1,57 @@
+import React, { Suspense, lazy } from 'react';
+
+const CKEditorComponent = lazy(() => import('@ckeditor/ckeditor5-react').then(mod => ({ default: mod.CKEditor })));
+const ClassicEditor = lazy(() => import('@ckeditor/ckeditor5-build-classic'));
+
+interface RichTextCKEditorProps {
+    label: string;
+    labelId: string;
+    value: string;
+    setData: (value: string) => void;
+    className?: string;
+}
+
+export default function RichTextCKEditor({
+    label,
+    labelId,
+    value,
+    setData,
+    className = 'min-h-[200px] max-h-[300px] h-fit w-full overflow-y-auto',
+}: RichTextCKEditorProps) {
+    return (
+        <div>
+            <label htmlFor={labelId} className="block text-sm font-medium text-gray-700 mb-1">
+                {label}
+            </label>
+            <Suspense fallback={<div>Loading editor...</div>}>
+                <CKEditorComponent
+                    editor={ClassicEditor}
+                    data={value}
+                    onChange={(_event: unknown, editor: any) => {
+                        const data = editor.getData();
+                        setData(data);
+                    }}
+                    config={{
+                        toolbar: {
+                            items: [
+                                'heading',
+                                '|',
+                                'bold',
+                                'italic',
+                                'link',
+                                'bulletedList',
+                                'numberedList',
+                                '|',
+                                'blockQuote',
+                                'undo',
+                                'redo',
+                            ],
+                        },
+                    }}
+                    id={labelId}
+                    className={className}
+                />
+            </Suspense>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add `RichTextCKEditor` component under `resources/js/components/ui/form`

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f06c11bc48333b704ad73f1eb7a50