### PR TITLE
Fix blog user assignment

### DIFF
--- a/app/Http/Requests/BlogStoreRequest.php
+++ b/app/Http/Requests/BlogStoreRequest.php
@@ -22,7 +22,6 @@ class BlogStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id'     => 'required|integer|exists:users,id',
             'title'       => 'required|string',
             'description' => 'required|string',
             'category_id' => 'nullable|integer|exists:blog_categories,id',

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Storage;
 class Blog extends Model
 {
     protected $fillable = [
+        'user_id',
         'title',
         'slug',
         'excerpt',

--- a/app/Repositories/BlogRepository.php
+++ b/app/Repositories/BlogRepository.php
@@ -39,7 +39,7 @@ class BlogRepository extends Repository
         ) : null;
 
         return self::create([
-            'user_id'          => $request->user_id,
+            'user_id'          => auth()->id(),
             'media_id'         => $media ? $media->id : null,
             'blog_category_id' => $request->category_id,
             'title'            => $request->title,
@@ -70,7 +70,7 @@ class BlogRepository extends Repository
         }
 
         return self::update($blog, [
-            'user_id'          => $request->user_id,
+            'user_id'          => $blog->user_id,
             'media_id'         => $media ? $media->id : null,
             'blog_category_id' => $request->category_id,
             'title'            => $request->title,


### PR DESCRIPTION
## Summary
- allow setting user_id on Blog model
- determine blog author from the authenticated user when creating a blog
- drop user_id requirement from blog store request

## Testing
- `composer install` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687f550a844c833383312c7b1dafbbf3